### PR TITLE
Publish jazzer plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,3 +2,16 @@ plugins {
     id "io.micronaut.build.internal.docs"
     id "io.micronaut.build.internal.quality-reporting"
 }
+
+// These tasks are used in the release workflow, but the jazzer plugin is an included build
+["publishAllPublicationsToBuildRepository", "publishToSonatype", "closeAndReleaseSonatypeStagingRepository"].each {t ->
+    if (tasks.names.find { it == t } == null) {
+        tasks.register(t) {
+            dependsOn(gradle.includedBuilds.find { it.name == "micronaut-jazzer-plugin" }.task(":$t"))
+        }
+    } else {
+        tasks.named(t) {
+            dependsOn(gradle.includedBuilds.find { it.name == "micronaut-jazzer-plugin" }.task(":$t"))
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.fuzzing-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.fuzzing-module.gradle
@@ -2,3 +2,9 @@ plugins {
     id 'io.micronaut.build.internal.fuzzing-base'
     id "io.micronaut.build.internal.module"
 }
+
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter "1.0.0"
+    }
+}

--- a/fuzzing-annotation-processor/src/main/java/io/micronaut/fuzzing/processor/DefinedFuzzTarget.java
+++ b/fuzzing-annotation-processor/src/main/java/io/micronaut/fuzzing/processor/DefinedFuzzTarget.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing.processor;
 
 import java.util.List;

--- a/fuzzing-annotation-processor/src/main/java/io/micronaut/fuzzing/processor/FuzzTargetVisitor.java
+++ b/fuzzing-annotation-processor/src/main/java/io/micronaut/fuzzing/processor/FuzzTargetVisitor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing.processor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/fuzzing-api/src/main/java/io/micronaut/fuzzing/Dict.java
+++ b/fuzzing-api/src/main/java/io/micronaut/fuzzing/Dict.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing;
 
 import java.lang.annotation.ElementType;

--- a/fuzzing-api/src/main/java/io/micronaut/fuzzing/DictResource.java
+++ b/fuzzing-api/src/main/java/io/micronaut/fuzzing/DictResource.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing;
 
 import java.lang.annotation.ElementType;

--- a/fuzzing-api/src/main/java/io/micronaut/fuzzing/FuzzTarget.java
+++ b/fuzzing-api/src/main/java/io/micronaut/fuzzing/FuzzTarget.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing;
 
 import java.lang.annotation.ElementType;

--- a/fuzzing-api/src/main/java/io/micronaut/fuzzing/HttpDict.java
+++ b/fuzzing-api/src/main/java/io/micronaut/fuzzing/HttpDict.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing;
 
 import java.lang.annotation.ElementType;

--- a/fuzzing-tests/gradle.properties
+++ b/fuzzing-tests/gradle.properties
@@ -1,0 +1,1 @@
+micronautPublish=false

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/ByteSeparator.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/ByteSeparator.java
@@ -28,7 +28,7 @@ import java.util.function.Consumer;
  * This class splits a byte input into multiple chunks in a fuzzer-friendly way, using the
  * {@link ByteSeparator#SEPARATOR}. Take care to add the separator to the fuzzer dictionary!
  */
-public class ByteSeparator {
+public final class ByteSeparator {
     static final String SEPARATOR = "SEP";
     private static final ByteBuf SEPARATOR_BYTES = Unpooled.copiedBuffer(SEPARATOR, StandardCharsets.UTF_8);
 

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/ByteSeparator.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/ByteSeparator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing.http;
 
 import io.netty.buffer.ByteBuf;

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/CustomResourceLeakDetector.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/CustomResourceLeakDetector.java
@@ -40,10 +40,15 @@ final class CustomResourceLeakDetector<T> extends ResourceLeakDetector<T> {
         }
     }
 
-    private static final List<Leak> leaks = new CopyOnWriteArrayList<>();
-    private static final List<ResourceLeakDetector<?>> detectors = new CopyOnWriteArrayList<>();
+    private static final List<Leak> LEAKS = new CopyOnWriteArrayList<>();
+    private static final List<ResourceLeakDetector<?>> DETECTORS = new CopyOnWriteArrayList<>();
 
     private static volatile ResourceLeakHint currentHint = new FixedHint(null);
+
+    public CustomResourceLeakDetector(Class<?> resourceType, int samplingInterval) {
+        super(resourceType, samplingInterval);
+        DETECTORS.add(this);
+    }
 
     static void register() {
         ResourceLeakDetector.setLevel(Level.PARANOID);
@@ -60,11 +65,6 @@ final class CustomResourceLeakDetector<T> extends ResourceLeakDetector<T> {
         currentHint = new FixedHint(input);
     }
 
-    public CustomResourceLeakDetector(Class<?> resourceType, int samplingInterval) {
-        super(resourceType, samplingInterval);
-        detectors.add(this);
-    }
-
     @Override
     protected boolean needReport() {
         return true;
@@ -72,13 +72,13 @@ final class CustomResourceLeakDetector<T> extends ResourceLeakDetector<T> {
 
     @Override
     protected void reportTracedLeak(String resourceType, String records) {
-        leaks.add(new Leak(resourceType, records));
+        LEAKS.add(new Leak(resourceType, records));
         super.reportTracedLeak(resourceType, records);
     }
 
     @Override
     protected void reportUntracedLeak(String resourceType) {
-        leaks.add(new Leak(resourceType, null));
+        LEAKS.add(new Leak(resourceType, null));
         super.reportUntracedLeak(resourceType);
     }
 
@@ -88,9 +88,9 @@ final class CustomResourceLeakDetector<T> extends ResourceLeakDetector<T> {
     }
 
     static void reportLeaks() {
-        if (!leaks.isEmpty()) {
+        if (!LEAKS.isEmpty()) {
             StringBuilder msg = new StringBuilder("Reported leaks! Probably unrelated to this particular run, though.\n");
-            for (Leak leak : leaks) {
+            for (Leak leak : LEAKS) {
                 msg.append(leak.resourceType).append("\n");
                 msg.append(leak.records).append("\n");
             }
@@ -101,7 +101,7 @@ final class CustomResourceLeakDetector<T> extends ResourceLeakDetector<T> {
     static void reportStillOpen() {
         Logger logger = LoggerFactory.getLogger(CustomResourceLeakDetector.class);
         String found = null;
-        for (ResourceLeakDetector<?> detector : detectors) {
+        for (ResourceLeakDetector<?> detector : DETECTORS) {
             Set<?> s = (Set<?>) ALL_LEAKS_FIELD.get(detector);
             for (Object o : s) {
                 String v = o.toString();
@@ -118,9 +118,10 @@ final class CustomResourceLeakDetector<T> extends ResourceLeakDetector<T> {
         }
     }
 
-    private record Leak(String resourceType, String records) {}
+    private record Leak(String resourceType, String records) {
+    }
 
-    private static class FixedHint implements ResourceLeakHint {
+    private static final class FixedHint implements ResourceLeakHint {
         private final byte[] associatedInput;
 
         private FixedHint(byte[] associatedInput) {

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/SimpleController.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/SimpleController.java
@@ -23,14 +23,10 @@ import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Post;
 import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Singleton
 @Controller
-public class SimpleController {
-    private static final Logger LOG = LoggerFactory.getLogger(SimpleController.class);
-
+public final class SimpleController {
     static final String ECHO_PUBLISHER = "/echo-publisher";
     static final String ECHO_ARRAY = "/echo-array";
     static final String ECHO_STRING = "/echo-string";

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,6 @@
 projectVersion=1.0.0-SNAPSHOT
 projectGroup=io.micronaut.fuzzing
 
-micronautPublish=false
-
 title=Micronaut fuzzing
 projectDesc=TODO
 projectUrl=https://micronaut.io

--- a/jazzer-plugin/build.gradle.kts
+++ b/jazzer-plugin/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("java-gradle-plugin")
+    id("io.micronaut.build.internal.publishing")
 }
 
 repositories {

--- a/jazzer-plugin/gradle.properties
+++ b/jazzer-plugin/gradle.properties
@@ -1,0 +1,1 @@
+projectDesc=A Gradle plugin integrating with Jazzer

--- a/jazzer-plugin/settings.gradle.kts
+++ b/jazzer-plugin/settings.gradle.kts
@@ -1,7 +1,7 @@
-rootProject.name = "jazzer-plugin"
+rootProject.name = "micronaut-jazzer-plugin"
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "7.3.0"
+    id("io.micronaut.build.shared.settings") version "7.3.1"
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,11 +3,13 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
     }
-    includeBuild("jazzer-plugin")
+    includeBuild("jazzer-plugin") {
+        name = "micronaut-jazzer-plugin"
+    }
 }
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "7.3.0"
+    id("io.micronaut.build.shared.settings") version "7.3.1"
 }
 
 rootProject.name = "fuzzing-parent"


### PR DESCRIPTION
This commit adds publishing of the Jazzer plugin. It will NOT be published on the Gradle plugin portal, but on Maven Central only. This shouldn't be an issue, except that users won't be able to find it when searching on the plugin portal (similarly to the native build tools).

It may be worth checking before a 1.0.0 release with a beta version or something, since the setup is a bit special.

Fixes #100