### PR TITLE
Fix release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=0.1.0
+projectVersion=0.1.0-SNAPSHOT
 projectGroup=io.micronaut.fuzzing
 
 title=Micronaut fuzzing

--- a/jazzer-plugin/settings.gradle.kts
+++ b/jazzer-plugin/settings.gradle.kts
@@ -5,7 +5,7 @@ pluginManagement {
 rootProject.name = "micronaut-jazzer-plugin"
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "7.3.1"
+    id("io.micronaut.build.shared.settings") version "7.3.2"
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ pluginManagement {
 }
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "7.3.1"
+    id("io.micronaut.build.shared.settings") version "7.3.2"
 }
 
 rootProject.name = "fuzzing-parent"


### PR DESCRIPTION
By upgrading to Micronaut Build 7.3.2. Tested locally, but I still cannot guarantee that the publication of the Gradle plugin will work correctly since we didn't get to the sonatype tasks yet and that it's a bit special (included build).

Note: this PR restores -SNAPSHOT, for the sake of being safe.