### PR TITLE
add fuzzing target for JsonBeanPropertyBinder

### DIFF
--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/bind/BuggyBeanPropertyBinderFactory.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/bind/BuggyBeanPropertyBinderFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.fuzzing.bind;
+
+import io.micronaut.context.BeanProvider;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.bind.BeanPropertyBinder;
+import io.micronaut.json.JsonConfiguration;
+import io.micronaut.json.JsonMapper;
+import io.micronaut.json.bind.JsonBeanPropertyBinderExceptionHandler;
+import jakarta.inject.Singleton;
+
+
+@Factory
+@Requires(property = "fuzzing.buggy-binder", value = "true")
+public class BuggyBeanPropertyBinderFactory {
+
+    @Singleton
+    @Replaces(BeanPropertyBinder.class)
+    public BeanPropertyBinder buggyBinder(
+        JsonMapper jsonMapper,
+        JsonConfiguration configuration,
+        BeanProvider<JsonBeanPropertyBinderExceptionHandler> exceptionHandlers) {
+        return new JsonBeanPropertyBinder(jsonMapper, configuration, exceptionHandlers);
+    }
+}

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/bind/JsonBeanPropertyBinder.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/bind/JsonBeanPropertyBinder.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.fuzzing.bind;
+
+import io.micronaut.context.BeanProvider;
+import io.micronaut.core.bind.BeanPropertyBinder;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionError;
+import io.micronaut.core.convert.exceptions.ConversionErrorException;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.json.JsonConfiguration;
+import io.micronaut.json.JsonMapper;
+import io.micronaut.json.bind.JsonBeanPropertyBinderExceptionHandler;
+import io.micronaut.json.tree.JsonNode;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+
+final class JsonBeanPropertyBinder implements BeanPropertyBinder {
+
+    private final JsonMapper jsonMapper;
+    private final int arraySizeThreshold;
+    private final BeanProvider<JsonBeanPropertyBinderExceptionHandler> exceptionHandlers;
+
+    /**
+     * @param jsonMapper To read/write JSON
+     * @param configuration The configuration for Jackson JSON parser
+     * @param exceptionHandlers Exception handlers for binding exceptions
+     */
+    JsonBeanPropertyBinder(JsonMapper jsonMapper, JsonConfiguration configuration, BeanProvider<JsonBeanPropertyBinderExceptionHandler> exceptionHandlers) {
+        this.jsonMapper = jsonMapper;
+        this.arraySizeThreshold = configuration.getArraySizeThreshold();
+        this.exceptionHandlers = exceptionHandlers;
+    }
+
+    @Override
+    public BindingResult<Object> bind(ArgumentConversionContext<Object> context, Map<CharSequence, ? super Object> source) {
+        try {
+            JsonNode objectNode = buildSourceObjectNode(source.entrySet());
+            Object result = jsonMapper.readValueFromTree(objectNode, context.getArgument());
+            return () -> Optional.of(result);
+        } catch (Exception e) {
+            context.reject(e);
+            return new BindingResult<>() {
+                @Override
+                public List<ConversionError> getConversionErrors() {
+                    return CollectionUtils.iterableToList(context);
+                }
+
+                @Override
+                public boolean isSatisfied() {
+                    return false;
+                }
+
+                @Override
+                public Optional<Object> getValue() {
+                    return Optional.empty();
+                }
+            };
+        }
+    }
+
+    @Override
+    public <T2> T2 bind(Class<T2> type, Set<? extends Map.Entry<? extends CharSequence, Object>> source) throws ConversionErrorException {
+        try {
+            JsonNode objectNode = buildSourceObjectNode(source);
+            return jsonMapper.readValueFromTree(objectNode, type);
+        } catch (Exception e) {
+            throw newConversionError(null, e);
+        }
+    }
+
+    @Override
+    public <T2> T2 bind(T2 object, ArgumentConversionContext<T2> context, Set<? extends Map.Entry<? extends CharSequence, Object>> source) {
+        try {
+            JsonNode objectNode = buildSourceObjectNode(source);
+            jsonMapper.updateValueFromTree(object, objectNode);
+        } catch (Exception e) {
+            context.reject(e);
+        }
+        return object;
+    }
+
+    @Override
+    public <T2> T2 bind(T2 object, Set<? extends Map.Entry<? extends CharSequence, Object>> source) throws ConversionErrorException {
+        try {
+            JsonNode objectNode = buildSourceObjectNode(source);
+            jsonMapper.updateValueFromTree(object, objectNode);
+        } catch (Exception e) {
+            throw newConversionError(object, e);
+        }
+        return object;
+    }
+
+    /**
+     * @param object The bean
+     * @param e The exception object
+     * @return The new conversion error
+     */
+    private ConversionErrorException newConversionError(Object object, Exception e) {
+        for (JsonBeanPropertyBinderExceptionHandler exceptionHandler : exceptionHandlers) {
+            Optional<ConversionErrorException> handled = exceptionHandler.toConversionError(object, e);
+            if (handled.isPresent()) {
+                return handled.get();
+            }
+        }
+        Class<?> type = object != null ? object.getClass() : Object.class;
+        return new ConversionErrorException(Argument.of(type), e);
+    }
+
+    private JsonNode buildSourceObjectNode(Set<? extends Map.Entry<? extends CharSequence, Object>> source) throws IOException {
+        var rootNode = new ObjectBuilder();
+        for (Map.Entry<? extends CharSequence, ? super Object> entry : source) {
+            CharSequence key = entry.getKey();
+            Object value = entry.getValue();
+            String property = key.toString();
+            ObjectBuilder current = rootNode;
+            String index = null;
+            Iterator<String> tokenIterator = StringUtils.splitOmitEmptyStringsIterator(property, '.');
+            while (tokenIterator.hasNext()) {
+                String token = tokenIterator.next();
+                int j = token.indexOf('[');
+                if (j > -1 && token.endsWith("]")) {
+                    index = token.substring(j + 1, token.length() - 1);
+                    token = token.substring(0, j);
+                }
+
+                if (!tokenIterator.hasNext()) {
+                    if (index != null) {
+                        current = getOrCreateObjectAtKey(current, index);
+                    }
+                    JsonNode valueNode = jsonMapper.writeValueToTree(value);
+                    if (current == rootNode && valueNode.isValueNode()) {
+                        // Store root values as an array of a single value to
+                        // simplify deserialization cases of usersId=1&usersId=2 vs usersId=1 into a collection
+                        ArrayBuilder array = new ArrayBuilder();
+                        array.values.add(new FixedValue(valueNode));
+                        current.values.put(token, array);
+                    } else {
+                        current.values.put(token, new FixedValue(valueNode));
+                    }
+                } else {
+                    if (index != null) {
+                        if (StringUtils.isDigits(index)) {
+                            ArrayBuilder arrayNode = getOrCreateArrayAtKey(current, token);
+                            int arrayIndex = Integer.parseInt(index);
+                            expandArrayToThreshold(arrayIndex, arrayNode);
+                            current = getOrCreateNodeAtIndex(arrayNode, arrayIndex);
+                        } else {
+                            ObjectBuilder objectNode = getOrCreateObjectAtKey(current, token);
+                            current = getOrCreateObjectAtKey(objectNode, index);
+                        }
+                        index = null;
+                    } else {
+                        current = getOrCreateObjectAtKey(current, token);
+                    }
+                }
+            }
+        }
+        return rootNode.build();
+    }
+
+    private ObjectBuilder getOrCreateObjectAtKey(ObjectBuilder objectNode, String key) {
+        ValueBuilder valueBuilder = objectNode.values.get(key);
+        if (valueBuilder instanceof ObjectBuilder objectBuilder) {
+            return objectBuilder;
+        }
+        ObjectBuilder objectBuilder = new ObjectBuilder();
+        objectNode.values.put(key, objectBuilder);
+        return objectBuilder;
+    }
+
+    private ArrayBuilder getOrCreateArrayAtKey(ObjectBuilder objectNode, String key) {
+        ValueBuilder valueBuilder = objectNode.values.get(key);
+        if (valueBuilder instanceof ArrayBuilder arrayBuilder) {
+            return arrayBuilder;
+        }
+        var arrayBuilder = new ArrayBuilder();
+        objectNode.values.put(key, arrayBuilder);
+        return arrayBuilder;
+    }
+
+    private ObjectBuilder getOrCreateNodeAtIndex(ArrayBuilder arrayNode, int arrayIndex) {
+        ValueBuilder jsonNode = arrayNode.values.get(arrayIndex);
+        if (jsonNode instanceof ObjectBuilder objectBuilder) {
+            return objectBuilder;
+        }
+        var objectBuilder = new ObjectBuilder();
+        arrayNode.values.set(arrayIndex, objectBuilder);
+        return objectBuilder;
+    }
+
+    private void expandArrayToThreshold(int arrayIndex, ArrayBuilder arrayNode) {
+        if (arrayIndex < arraySizeThreshold) {
+            while (arrayNode.values.size() != arrayIndex + 1) {
+                arrayNode.values.add(FixedValue.NULL);
+            }
+        }
+    }
+
+    private interface ValueBuilder {
+        JsonNode build();
+    }
+
+    private static final class FixedValue implements ValueBuilder {
+        static final FixedValue NULL = new FixedValue(JsonNode.nullNode());
+
+        final JsonNode value;
+
+        FixedValue(JsonNode value) {
+            this.value = value;
+        }
+
+        @Override
+        public JsonNode build() {
+            return value;
+        }
+    }
+
+    private static final class ObjectBuilder implements ValueBuilder {
+        final Map<String, ValueBuilder> values = new LinkedHashMap<>();
+
+        @Override
+        public JsonNode build() {
+            var built = CollectionUtils.<String, JsonNode>newLinkedHashMap(values.size());
+            for (Map.Entry<String, ValueBuilder> entry : values.entrySet()) {
+                built.put(entry.getKey(), entry.getValue().build());
+            }
+            return JsonNode.createObjectNode(built);
+        }
+    }
+
+    private static final class ArrayBuilder implements ValueBuilder {
+        final List<ValueBuilder> values = new ArrayList<>();
+
+        @Override
+        public JsonNode build() {
+            return JsonNode.createArrayNode(values.stream().map(ValueBuilder::build).toList());
+        }
+    }
+}

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/bind/JsonBeanPropertyBinderTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/bind/JsonBeanPropertyBinderTarget.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.fuzzing.bind;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.BeanProvider;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.bind.ArgumentBinder;
+import io.micronaut.core.bind.BeanPropertyBinder;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.ConversionError;
+import io.micronaut.core.convert.exceptions.ConversionErrorException;
+import io.micronaut.core.type.Argument;
+import io.micronaut.fuzzing.Dict;
+import io.micronaut.fuzzing.FuzzTarget;
+import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import io.micronaut.json.JsonConfiguration;
+import io.micronaut.json.JsonMapper;
+import io.micronaut.json.bind.JsonBeanPropertyBinderExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+
+@FuzzTarget
+@Dict({
+    "name=", "age=", "value=", "email=", "id=",
+
+    "address.street=", "address.city=", "meta.key=",
+
+    "items[0].", "items[1].", "items[3].", "items[5].", "items[9].", "items[99].",
+    "authors[0].name=", "authors[3].name=", "authors[5].name=", "authors[99].name=",
+    "tags[0]=", "tags[2]=", "tags[5]=",
+
+    "map[key].value=", "map[foo].bar=",
+
+    "&", ".",
+})
+public class JsonBeanPropertyBinderTarget {
+
+    private static final BeanPropertyBinder BINDER;
+
+    static {
+        ApplicationContext ctx = ApplicationContext.run(Map.of());
+        JsonMapper jsonMapper = ctx.getBean(JsonMapper.class);
+        JsonConfiguration jsonConfig = ctx.getBean(JsonConfiguration.class);
+        BeanProvider<JsonBeanPropertyBinderExceptionHandler> handlers =
+            ctx.getBean(Argument.of(BeanProvider.class, JsonBeanPropertyBinderExceptionHandler.class));
+        BINDER = new JsonBeanPropertyBinder(jsonMapper, jsonConfig, handlers);
+    }
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        int entryCount = data.consumeInt(1, 8);
+        Map<String, Object> params = new LinkedHashMap<>();
+        for (int i = 0; i < entryCount; i++) {
+            params.put(buildKey(data), data.consumeString(20));
+        }
+
+        int scenario = data.consumeInt(0, 3);
+        switch (scenario) {
+            case 0 -> bindNewFlat(params);
+            case 1 -> bindExistingFlat(params);
+            case 2 -> bindNewNested(params);
+            case 3 -> bindViaArgumentContext(params);
+        }
+    }
+
+
+    private static void bindNewFlat(Map<String, Object> params) {
+        try {
+            BINDER.bind(FlatBean.class, params.entrySet());
+        } catch (ConversionErrorException e) {
+            surfaceIfUnexpected(e);
+        }
+    }
+
+    private static void bindExistingFlat(Map<String, Object> params) {
+        try {
+            BINDER.bind(new FlatBean(), params.entrySet());
+        } catch (ConversionErrorException e) {
+            surfaceIfUnexpected(e);
+        }
+    }
+
+    private static void bindNewNested(Map<String, Object> params) {
+        try {
+            BINDER.bind(NestedBean.class, params.entrySet());
+        } catch (ConversionErrorException e) {
+            surfaceIfUnexpected(e);
+        }
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private static void bindViaArgumentContext(Map<String, Object> params) {
+        Argument<NestedBean> arg = Argument.of(NestedBean.class);
+        ArgumentConversionContext<Object> ctx =
+            (ArgumentConversionContext<Object>) (ArgumentConversionContext<?>) ConversionContext.of(arg);
+        Map<CharSequence, Object> charSeqMap = new LinkedHashMap<>(params);
+        ArgumentBinder<Object, Map<CharSequence, ? super Object>> binder = BINDER;
+        binder.bind(ctx, charSeqMap);
+        for (ConversionError error : ctx) {
+            surfaceIfUnexpected(error.getCause());
+        }
+    }
+
+
+    private static void surfaceIfUnexpected(ConversionErrorException e) {
+        surfaceIfUnexpected(e.getCause());
+    }
+
+    private static void surfaceIfUnexpected(Throwable cause) {
+        if (cause instanceof IndexOutOfBoundsException e) {
+            throw e;
+        } else if (cause instanceof NullPointerException e) {
+            throw e;
+        } else if (cause instanceof StackOverflowError e) {
+            throw e;
+        }
+    }
+
+
+
+    private static String buildKey(FuzzedDataProvider data) {
+        return data.consumeString(30);
+    }
+
+
+
+
+    @Introspected
+    public static class FlatBean {
+        @Nullable private String name;
+        @Nullable private Integer age;
+        @Nullable private String email;
+        @Nullable private Boolean active;
+
+        @Nullable public String getName() { return name; }
+        public void setName(@Nullable String name) { this.name = name; }
+
+        @Nullable public Integer getAge() { return age; }
+        public void setAge(@Nullable Integer age) { this.age = age; }
+
+        @Nullable public String getEmail() { return email; }
+        public void setEmail(@Nullable String email) { this.email = email; }
+
+        @Nullable public Boolean getActive() { return active; }
+        public void setActive(@Nullable Boolean active) { this.active = active; }
+    }
+
+
+    @Introspected
+    public static class NestedBean {
+        @Nullable private List<ItemEntry> items;
+        @Nullable private String label;
+
+        @Nullable public List<ItemEntry> getItems() { return items; }
+        public void setItems(@Nullable List<ItemEntry> items) { this.items = items; }
+
+        @Nullable public String getLabel() { return label; }
+        public void setLabel(@Nullable String label) { this.label = label; }
+    }
+
+
+    @Introspected
+    public static class ItemEntry {
+        @Nullable private String value;
+        @Nullable private Integer count;
+
+        @Nullable public String getValue() { return value; }
+        public void setValue(@Nullable String value) { this.value = value; }
+
+        @Nullable public Integer getCount() { return count; }
+        public void setCount(@Nullable Integer count) { this.count = count; }
+    }
+
+    public static void main(String[] args) {
+        LocalJazzerRunner.create(JsonBeanPropertyBinderTarget.class).fuzz();
+    }
+}

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/AuthorEntry.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/AuthorEntry.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.fuzzing.http;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Nullable;
+
+@Introspected
+public class AuthorEntry {
+    @Nullable
+    private String name;
+
+    @Nullable
+    private Integer age;
+
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    public void setName(@Nullable String name) {
+        this.name = name;
+    }
+
+    @Nullable
+    public Integer getAge() {
+        return age;
+    }
+
+    public void setAge(@Nullable Integer age) {
+        this.age = age;
+    }
+}

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/AuthorForm.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/AuthorForm.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.fuzzing.http;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Nullable;
+import java.util.List;
+
+
+@Introspected
+public class AuthorForm {
+    @Nullable
+    private List<AuthorEntry> authors;
+
+    @Nullable
+    public List<AuthorEntry> getAuthors() {
+        return authors;
+    }
+
+    public void setAuthors(@Nullable List<AuthorEntry> authors) {
+        this.authors = authors;
+    }
+}

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/EmbeddedHttpBindingTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/EmbeddedHttpBindingTarget.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.fuzzing.http;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.fuzzing.Dict;
+import io.micronaut.fuzzing.EmbeddedChannelFuzzerBase;
+import io.micronaut.fuzzing.FuzzTarget;
+import io.micronaut.fuzzing.HttpDict;
+import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import io.micronaut.http.server.netty.NettyHttpServer;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.slf4j.LoggerFactory;
+
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@FuzzTarget
+@HttpDict
+@Dict({
+
+    SimpleController.ECHO_AUTHORS,
+    "application/x-www-form-urlencoded",
+    "authors[0].name=", "authors[1].name=", "authors[3].name=", "authors[5].name=",
+    "authors[0].age=",  "authors[99].name=",
+    "&",
+})
+public class EmbeddedHttpBindingTarget extends EmbeddedChannelFuzzerBase {
+    private static final ContextHolder HTTP1 = new ContextHolder(Map.of("fuzzing.buggy-binder", "true"));
+
+    EmbeddedHttpBindingTarget(ContextHolder contextHolder) {
+        super(contextHolder.nettyHttpServer.buildEmbeddedChannel(false));
+        baseCpuTime = 5_000_000;
+    }
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider input) {
+        new EmbeddedHttpBindingTarget(HTTP1).test(input);
+    }
+
+    static void main(String[] args) {
+        LocalJazzerRunner.create(EmbeddedHttpBindingTarget.class).reproduce("GET / HTTP/1.1\r\nContent-Length: 0\r\nHost: localhost\r\nConnection: close\r\n\r\n".getBytes(StandardCharsets.UTF_8));
+    }
+
+    static final class ContextHolder {
+        final NettyHttpServer nettyHttpServer;
+
+        ContextHolder(Map<String, Object> cfg) {
+            String vmName = ManagementFactory.getRuntimeMXBean().getName();
+            System.setProperty("VM_NAME", vmName);
+            LoggerFactory.getLogger(EmbeddedHttpBindingTarget.class).info("Starting embedded HTTP target. VM name is: {}", vmName);
+
+            ApplicationContext ctx = ApplicationContext.run(cfg);
+
+            nettyHttpServer = (NettyHttpServer) ctx.getBean(EmbeddedServer.class);
+        }
+    }
+}

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/SimpleController.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/SimpleController.java
@@ -27,6 +27,8 @@ import io.micronaut.http.annotation.QueryValue;
 import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
 
+import java.util.List;
+
 @Singleton
 @Controller
 public final class SimpleController {
@@ -39,6 +41,7 @@ public final class SimpleController {
     static final String ECHO_HEADER = "/echo-header";
     static final String ECHO_FORM = "/echo-form";
     static final String ECHO_FORM_PAIR = "/echo-form-pair";
+    static final String ECHO_AUTHORS = "/echo-authors";
 
     @Get
     public String index() {
@@ -93,5 +96,11 @@ public final class SimpleController {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     public String echoFormPair(@Body("foo") String foo, @Body("bar") String bar) {
         return foo + ":" + bar;
+    }
+    @Post(ECHO_AUTHORS)
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public String echoAuthors(@Body AuthorForm form) {
+        List<AuthorEntry> authors = form.getAuthors();
+        return authors == null ? "empty" : "count:" + authors.size();
     }
 }


### PR DESCRIPTION
 - JsonBeanPropertyBinderTarget: fuzz target exercising  binding scenarios using Jazzer                                                                                                                                              
  - JsonBeanPropertyBinder: local copy of the binder under test (reproducer)                                                                                                    
  - BuggyBeanPropertyBinderFactory: factory to swap in the buggy binder via                                                                                                     
    the 'fuzzing.buggy-binder' property                                                                                                                                         
  - AuthorEntry, AuthorForm, EmbeddedHttpBindingTarget: supporting beans for                                                                                                    
    HTTP-level binding scenarios          