### PR TITLE
Apply license formatting to fuzzing tests

### DIFF
--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/CpuTestTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/CpuTestTarget.java
@@ -1,13 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import io.micronaut.fuzzing.runner.LocalJazzerRunner;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget(enableImplicitly = false)
 public class CpuTestTarget {
     public static void fuzzerTestOneInput(FuzzedDataProvider provider) {
         long start = CpuTimer.currentThreadCpuTimeNanos();
-        System.out.println(collatz(provider.consumeInt()));;
+        System.out.println(collatz(provider.consumeInt()));
         long end = CpuTimer.currentThreadCpuTimeNanos();
         if (end > start + 1_000_000_000L) {
             throw new IllegalStateException("took too long (" + (end - start) + ")");

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/CpuTimer.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/CpuTimer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing;
 
 import java.lang.foreign.Arena;
@@ -11,74 +26,72 @@ import java.lang.foreign.ValueLayout;
 /**
  * Returns the current thread CPU time using Linux clock_gettime(CLOCK_THREAD_CPUTIME_ID)
  * via the Java Foreign Function & Memory API.
- *
- * @author AI
  */
 @SuppressWarnings({"Since15", "preview"})
 public final class CpuTimer {
+    private static final int CLOCK_THREAD_CPUTIME_ID = 3;
+    private static final long NANO_PER_SEC = 1_000_000_000L;
+
     private CpuTimer() {
     }
 
-    // Linux clock id for per-thread CPU time
-    private static final int CLOCK_THREAD_CPUTIME_ID = 3;
-
-    private static final long NANO_PER_SEC = 1_000_000_000L;
-
-    // struct timespec { time_t tv_sec; long tv_nsec; }
-    // On Linux x86_64 both are 8-byte longs.
-    private static final MemoryLayout TIMESPEC_LAYOUT = MemoryLayout.structLayout(
-        ValueLayout.JAVA_LONG.withName("tv_sec"),
-        ValueLayout.JAVA_LONG.withName("tv_nsec")
-    );
-
-    private static final long OFF_TV_SEC = TIMESPEC_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("tv_sec"));
-    private static final long OFF_TV_NSEC = TIMESPEC_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("tv_nsec"));
-
-    private static final Linker LINKER = Linker.nativeLinker();
-    private static final FunctionDescriptor FD_CLOCK_GETTIME = FunctionDescriptor.of(
-        ValueLayout.JAVA_INT,       // return type: int
-        ValueLayout.JAVA_INT,       // clockid_t
-        ValueLayout.ADDRESS         // struct timespec*
-    );
-
-    private static final Arena LOOKUP_ARENA = Arena.ofAuto();
-    private static final java.lang.invoke.MethodHandle MH_CLOCK_GETTIME;
-
-    static {
-        try {
-            SymbolLookup lookup;
-            try {
-                // Prefer the default platform lookup if available (JDK 22+)
-                lookup = LINKER.defaultLookup();
-            } catch (Throwable ignore) {
-                // Fallback to libc lookup
-                lookup = SymbolLookup.libraryLookup("c", LOOKUP_ARENA);
+    /**
+     * Returns the current thread CPU time in nanoseconds.
+     *
+     * @return The CPU time from clock_gettime(CLOCK_THREAD_CPUTIME_ID)
+     */
+    public static long currentThreadCpuTimeNanos() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment ts = arena.allocate(NativeClock.TIMESPEC_LAYOUT);
+            int ret = (int) NativeClock.MH_CLOCK_GETTIME.invokeExact(CLOCK_THREAD_CPUTIME_ID, ts);
+            if (ret != 0) {
+                throw new IllegalStateException("clock_gettime failed with code " + ret);
             }
-            MemorySegment sym = lookup.find("clock_gettime")
-                .orElseGet(() -> SymbolLookup.libraryLookup("c", LOOKUP_ARENA).find("clock_gettime")
-                    .orElseThrow(() -> new UnsatisfiedLinkError("clock_gettime symbol not found")));
-            MH_CLOCK_GETTIME = LINKER.downcallHandle(sym, FD_CLOCK_GETTIME);
+            long sec = ts.get(ValueLayout.JAVA_LONG, NativeClock.OFF_TV_SEC);
+            long nsec = ts.get(ValueLayout.JAVA_LONG, NativeClock.OFF_TV_NSEC);
+            return sec * NANO_PER_SEC + nsec;
         } catch (Throwable t) {
-            throw new ExceptionInInitializerError(t);
+            throw new RuntimeException("Failed to invoke clock_gettime", t);
         }
     }
 
     /**
-     * Returns the current thread CPU time in nanoseconds, obtained from
-     * clock_gettime(CLOCK_THREAD_CPUTIME_ID).
+     * Lazily initialized native interop state.
      */
-    public static long currentThreadCpuTimeNanos() {
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment ts = arena.allocate(TIMESPEC_LAYOUT);
-            int ret = (int) MH_CLOCK_GETTIME.invokeExact(CLOCK_THREAD_CPUTIME_ID, ts);
-            if (ret != 0) {
-                throw new IllegalStateException("clock_gettime failed with code " + ret);
+    private static final class NativeClock {
+        private static final Linker LINKER = Linker.nativeLinker();
+        private static final Arena LOOKUP_ARENA = Arena.ofAuto();
+        private static final MemoryLayout TIMESPEC_LAYOUT = MemoryLayout.structLayout(
+            ValueLayout.JAVA_LONG.withName("tv_sec"),
+            ValueLayout.JAVA_LONG.withName("tv_nsec")
+        );
+        private static final FunctionDescriptor FD_CLOCK_GETTIME = FunctionDescriptor.of(
+            ValueLayout.JAVA_INT,
+            ValueLayout.JAVA_INT,
+            ValueLayout.ADDRESS
+        );
+        private static final long OFF_TV_SEC = TIMESPEC_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("tv_sec"));
+        private static final long OFF_TV_NSEC = TIMESPEC_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("tv_nsec"));
+        private static final java.lang.invoke.MethodHandle MH_CLOCK_GETTIME = createClockGettimeHandle();
+
+        private NativeClock() {
+        }
+
+        private static java.lang.invoke.MethodHandle createClockGettimeHandle() {
+            try {
+                SymbolLookup lookup;
+                try {
+                    lookup = LINKER.defaultLookup();
+                } catch (Throwable ignore) {
+                    lookup = SymbolLookup.libraryLookup("c", LOOKUP_ARENA);
+                }
+                MemorySegment sym = lookup.find("clock_gettime")
+                    .orElseGet(() -> SymbolLookup.libraryLookup("c", LOOKUP_ARENA).find("clock_gettime")
+                        .orElseThrow(() -> new UnsatisfiedLinkError("clock_gettime symbol not found")));
+                return LINKER.downcallHandle(sym, FD_CLOCK_GETTIME);
+            } catch (Throwable t) {
+                throw new ExceptionInInitializerError(t);
             }
-            long sec = ts.get(ValueLayout.JAVA_LONG, OFF_TV_SEC);
-            long nsec = ts.get(ValueLayout.JAVA_LONG, OFF_TV_NSEC);
-            return sec * NANO_PER_SEC + nsec;
-        } catch (Throwable t) {
-            throw new RuntimeException("Failed to invoke clock_gettime", t);
         }
     }
 }

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/EmbeddedChannelFuzzerBase.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/EmbeddedChannelFuzzerBase.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -16,22 +31,22 @@ import jdk.jfr.Enabled;
 import jdk.jfr.Event;
 import jdk.jfr.StackTrace;
 
-@Dict(EmbeddedChannelFuzzerBase.SEPARATOR)
+/**
+ * Base support for fuzz targets that drive an EmbeddedChannel with split byte input.
+ */
+@Dict("SEP")
 public abstract class EmbeddedChannelFuzzerBase {
     private static final long CPU_TIME_FACTOR = 1024;
-
-    static final String SEPARATOR = "SEP";
-    static final ByteSplitter SPLITTER = ByteSplitter.create(SEPARATOR);
+    private static final String SEPARATOR = "SEP";
+    private static final ByteSplitter SPLITTER = ByteSplitter.create(SEPARATOR);
 
     protected final EmbeddedChannel channel;
-
     protected long baseCpuTime = 500000;
     protected long inputCpuTime = 20;
     protected long outputCpuTime = 0;
     protected boolean hasOutput = false;
 
     private long outputBytes;
-
     private boolean finished = false;
     private boolean exceptionCaught = false;
 
@@ -47,6 +62,11 @@ public abstract class EmbeddedChannelFuzzerBase {
         FastThreadLocalThread.runWithFastThreadLocal(() -> test0(provider));
     }
 
+    /**
+     * Handles exceptions raised while fuzzing the channel.
+     *
+     * @param e The exception to surface
+     */
     protected void onException(Exception e) {
         PlatformDependent.throwException(e);
     }

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/FlagAppender.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/FlagAppender.java
@@ -18,6 +18,9 @@ package io.micronaut.fuzzing;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 
+/**
+ * Fuzzing support type.
+ */
 public class FlagAppender extends AppenderBase<ILoggingEvent> {
     private static volatile boolean triggered = false;
 

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/IngredientTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/IngredientTarget.java
@@ -35,7 +35,11 @@ public class IngredientTarget {
         }
     }
 
-    record Ingredient(
+    public static void main(String[] args) {
+        LocalJazzerRunner.create(IngredientTarget.class).fuzz();
+    }
+
+    private record Ingredient(
         String name,
         int massInGrams,
         int priceInCents
@@ -49,9 +53,5 @@ public class IngredientTarget {
         int pricePerKg() {
             return priceInCents * 1000 / massInGrams;
         }
-    }
-
-    public static void main(String[] args) {
-        LocalJazzerRunner.create(IngredientTarget.class).fuzz();
     }
 }

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/TestTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/TestTarget.java
@@ -18,6 +18,9 @@ package io.micronaut.fuzzing;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import io.micronaut.fuzzing.runner.LocalJazzerRunner;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget(enableImplicitly = false)
 public class TestTarget {
     public static void fuzzerTestOneInput(FuzzedDataProvider provider) {

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/bind/BuggyBeanPropertyBinderFactory.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/bind/BuggyBeanPropertyBinderFactory.java
@@ -26,9 +26,12 @@ import io.micronaut.json.bind.JsonBeanPropertyBinderExceptionHandler;
 import jakarta.inject.Singleton;
 
 
+/**
+ * Fuzzing support type.
+ */
 @Factory
 @Requires(property = "fuzzing.buggy-binder", value = "true")
-public class BuggyBeanPropertyBinderFactory {
+public final class BuggyBeanPropertyBinderFactory {
 
     @Singleton
     @Replaces(BeanPropertyBinder.class)

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/bind/JsonBeanPropertyBinderTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/bind/JsonBeanPropertyBinderTarget.java
@@ -38,7 +38,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @Dict({
     "name=", "age=", "value=", "email=", "id=",
@@ -79,9 +81,9 @@ public class JsonBeanPropertyBinderTarget {
             case 1 -> bindExistingFlat(params);
             case 2 -> bindNewNested(params);
             case 3 -> bindViaArgumentContext(params);
+            default -> throw new IllegalStateException("Unexpected scenario: " + scenario);
         }
     }
-
 
     private static void bindNewFlat(Map<String, Object> params) {
         try {
@@ -107,7 +109,6 @@ public class JsonBeanPropertyBinderTarget {
         }
     }
 
-
     @SuppressWarnings("unchecked")
     private static void bindViaArgumentContext(Map<String, Object> params) {
         Argument<NestedBean> arg = Argument.of(NestedBean.class);
@@ -120,7 +121,6 @@ public class JsonBeanPropertyBinderTarget {
             surfaceIfUnexpected(error.getCause());
         }
     }
-
 
     private static void surfaceIfUnexpected(ConversionErrorException e) {
         surfaceIfUnexpected(e.getCause());
@@ -136,62 +136,112 @@ public class JsonBeanPropertyBinderTarget {
         }
     }
 
-
-
+    /**
+     * Builds a fuzzed property key.
+     *
+     * @param data The fuzzed data provider
+     * @return A fuzzed property key
+     */
     private static String buildKey(FuzzedDataProvider data) {
         return data.consumeString(30);
     }
 
+    public static void main(String[] args) {
+        LocalJazzerRunner.create(JsonBeanPropertyBinderTarget.class).fuzz();
+    }
 
-
-
+    /** Simple flat bean used for binder fuzzing. */
     @Introspected
-    public static class FlatBean {
+    public static final class FlatBean {
         @Nullable private String name;
         @Nullable private Integer age;
         @Nullable private String email;
         @Nullable private Boolean active;
 
-        @Nullable public String getName() { return name; }
-        public void setName(@Nullable String name) { this.name = name; }
+        @Nullable
+        public String getName() {
+            return name;
+        }
 
-        @Nullable public Integer getAge() { return age; }
-        public void setAge(@Nullable Integer age) { this.age = age; }
+        public void setName(@Nullable String name) {
+            this.name = name;
+        }
 
-        @Nullable public String getEmail() { return email; }
-        public void setEmail(@Nullable String email) { this.email = email; }
+        @Nullable
+        public Integer getAge() {
+            return age;
+        }
 
-        @Nullable public Boolean getActive() { return active; }
-        public void setActive(@Nullable Boolean active) { this.active = active; }
+        public void setAge(@Nullable Integer age) {
+            this.age = age;
+        }
+
+        @Nullable
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(@Nullable String email) {
+            this.email = email;
+        }
+
+        @Nullable
+        public Boolean getActive() {
+            return active;
+        }
+
+        public void setActive(@Nullable Boolean active) {
+            this.active = active;
+        }
     }
 
-
+    /** Nested bean used for binder fuzzing. */
     @Introspected
-    public static class NestedBean {
+    public static final class NestedBean {
         @Nullable private List<ItemEntry> items;
         @Nullable private String label;
 
-        @Nullable public List<ItemEntry> getItems() { return items; }
-        public void setItems(@Nullable List<ItemEntry> items) { this.items = items; }
+        @Nullable
+        public List<ItemEntry> getItems() {
+            return items;
+        }
 
-        @Nullable public String getLabel() { return label; }
-        public void setLabel(@Nullable String label) { this.label = label; }
+        public void setItems(@Nullable List<ItemEntry> items) {
+            this.items = items;
+        }
+
+        @Nullable
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(@Nullable String label) {
+            this.label = label;
+        }
     }
 
-
+   /** Item entry used for nested list binding fuzzing. */
     @Introspected
-    public static class ItemEntry {
+    public static final class ItemEntry {
         @Nullable private String value;
         @Nullable private Integer count;
 
-        @Nullable public String getValue() { return value; }
-        public void setValue(@Nullable String value) { this.value = value; }
+        @Nullable
+        public String getValue() {
+            return value;
+        }
 
-        @Nullable public Integer getCount() { return count; }
-        public void setCount(@Nullable Integer count) { this.count = count; }
-    }
+        public void setValue(@Nullable String value) {
+            this.value = value;
+        }
 
-    public static void main(String[] args) {
-        LocalJazzerRunner.create(JsonBeanPropertyBinderTarget.class).fuzz();
+        @Nullable
+        public Integer getCount() {
+            return count;
+        }
+
+        public void setCount(@Nullable Integer count) {
+            this.count = count;
+        }
     }
 }

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/AuthorEntry.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/AuthorEntry.java
@@ -18,8 +18,11 @@ package io.micronaut.fuzzing.http;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Nullable;
 
+/**
+ * Fuzzing support type.
+ */
 @Introspected
-public class AuthorEntry {
+public final class AuthorEntry {
     @Nullable
     private String name;
 

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/AuthorForm.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/AuthorForm.java
@@ -20,8 +20,11 @@ import io.micronaut.core.annotation.Nullable;
 import java.util.List;
 
 
+/**
+ * Fuzzing support type.
+ */
 @Introspected
-public class AuthorForm {
+public final class AuthorForm {
     @Nullable
     private List<AuthorEntry> authors;
 

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/ContentNegotiationTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/ContentNegotiationTarget.java
@@ -23,6 +23,9 @@ import io.micronaut.http.MediaType;
 
 import java.util.List;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 @Dict({
@@ -102,7 +105,9 @@ public class ContentNegotiationTarget {
             int count = data.consumeInt(5, 50);
             StringBuilder accept = new StringBuilder();
             for (int i = 0; i < count; i++) {
-                if (i > 0) accept.append(",");
+                if (i > 0) {
+                    accept.append(",");
+                }
                 accept.append(data.consumeString(20));
                 accept.append(";q=");
                 accept.append(data.consumeString(5));

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/EmbeddedHttp2Target.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/EmbeddedHttp2Target.java
@@ -21,6 +21,9 @@ import io.micronaut.fuzzing.runner.LocalJazzerRunner;
 
 import java.util.Map;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 public class EmbeddedHttp2Target extends EmbeddedHttpTarget {
     private static final EmbeddedHttpTarget.ContextHolder HTTP2 = new EmbeddedHttpTarget.ContextHolder(Map.of("micronaut.server.http-version", "2.0"));

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/EmbeddedHttpBindingTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/EmbeddedHttpBindingTarget.java
@@ -30,6 +30,9 @@ import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 @Dict({

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/EmbeddedHttpTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/EmbeddedHttpTarget.java
@@ -30,6 +30,9 @@ import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 @Dict({

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/HttpTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/HttpTarget.java
@@ -39,6 +39,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget(enableImplicitly = false) // we prefer EmbeddedHttpTarget for now
 @HttpDict
 public class HttpTarget {

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/MediaTypeTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/MediaTypeTarget.java
@@ -22,6 +22,9 @@ import io.micronaut.http.MediaType;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 public class MediaTypeTarget {
     public static void fuzzerTestOneInput(FuzzedDataProvider input) throws Exception {

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/MultipartTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/MultipartTarget.java
@@ -31,6 +31,9 @@ import io.netty.contrib.multipart.PostBodyDecoder;
 
 import java.nio.charset.StandardCharsets;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 @Dict({
@@ -88,7 +91,9 @@ public class MultipartTarget {
     }
 
     private static String sanitizeBoundary(String raw) {
-        if (raw == null || raw.isEmpty()) return "fuzzBoundary";
+        if (raw == null || raw.isEmpty()) {
+            return "fuzzBoundary";
+        }
         String clean = raw.replaceAll("[^a-zA-Z0-9'()+_,-./:=?]", "x");
         return clean.isEmpty() ? "fuzzBoundary" : clean;
     }

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/RequestData.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/RequestData.java
@@ -22,8 +22,11 @@ import io.micronaut.http.annotation.Header;
 import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.QueryValue;
 
+/**
+ * Fuzzing support type.
+ */
 @Introspected
-public class RequestData {
+public final class RequestData {
     @PathVariable
     private String id;
 

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/SearchQuery.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/SearchQuery.java
@@ -18,8 +18,11 @@ package io.micronaut.fuzzing.http;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Nullable;
 
+/**
+ * Fuzzing support type.
+ */
 @Introspected
-public class SearchQuery {
+public final class SearchQuery {
     @Nullable
     private String keyword;
 

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/SimpleController.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/SimpleController.java
@@ -20,8 +20,8 @@ import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Consumes;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
-import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.core.annotation.Nullable;
@@ -36,8 +36,10 @@ import io.micronaut.http.annotation.Produces;
 import static io.micronaut.http.MediaType.MULTIPART_FORM_DATA;
 import io.micronaut.http.HttpResponse;
 
-import java.util.List;
 
+/**
+ * Simple HTTP endpoints used by fuzzing tests.
+ */
 @Singleton
 @Controller
 public final class SimpleController {
@@ -58,7 +60,7 @@ public final class SimpleController {
     static final String ECHO_REQUEST_BEAN = "/echo-request-bean";
     static final String ECHO_COOKIE = "/echo-cookie";
     static final String UPLOAD_MULTIPLE = "/upload-multiple";
-    static final String ECHO_NEGOTIATED  = "/echo-negotiated";
+    static final String ECHO_NEGOTIATED = "/echo-negotiated";
     static final String ECHO_MULTI_ACCEPT = "/echo-multi-accept";
 
     @Get
@@ -89,6 +91,7 @@ public final class SimpleController {
     public String echoPieceJson(@Body("foo") String foo) {
         return foo;
     }
+
     @Get(ECHO_QUERY + "{?foo}")
     public String echoQuery(@QueryValue String foo) {
         return foo;
@@ -127,37 +130,44 @@ public final class SimpleController {
     public String uploadFile(@Part("file") CompletedFileUpload file) {
         return "size:" + file.getSize();
     }
+
     @Post(value = UPLOAD_FIELDS, consumes = MULTIPART_FORM_DATA)
     public String uploadFields(@Part("username") String username,
-                               @Part("email") String email) {
+                                @Part("email") String email) {
         return username + "/" + email;
     }
+
     @Post(value = UPLOAD_MIXED, consumes = MULTIPART_FORM_DATA)
     public String uploadMixed(@Part("name") String name,
                               @Part("data") CompletedFileUpload data) {
         return name + ":" + data.getSize();
     }
+
     @Get(ECHO_BEAN + "{?keyword,page,active}")
     public String echoBean(SearchQuery query) {
         return query.getKeyword() + ":"
             + query.getPage() + ":"
             + query.getActive();
     }
+
     @Get(ECHO_REQUEST_BEAN + "/{id}{?filter}")
     public String echoRequestBean(@RequestBean RequestData data) {
         return data.getId() + ":"
             + data.getFilter() + ":"
             + data.getVersion();
     }
+
     @Get(ECHO_COOKIE)
     public String echoCookie(@CookieValue("session") @Nullable String session,
                              @CookieValue("theme") @Nullable String theme) {
         return session + ":" + theme;
     }
+
     @Post(value = UPLOAD_MULTIPLE, consumes = MULTIPART_FORM_DATA)
     public String uploadMultiple(@Part("files") CompletedFileUpload[] files) {
         return "count:" + files.length;
     }
+
     @Get(ECHO_NEGOTIATED)
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN})
     public String echoNegotiated(@QueryValue @Nullable String value) {

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/StableHttpHostResolver.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/StableHttpHostResolver.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing.http;
 
 import io.micronaut.context.BeanProvider;
@@ -8,6 +23,9 @@ import io.micronaut.http.server.util.DefaultHttpHostResolver;
 import io.micronaut.runtime.server.EmbeddedServer;
 import jakarta.inject.Singleton;
 
+/**
+ * Fuzzing support type.
+ */
 @Singleton
 @Replaces(DefaultHttpHostResolver.class)
 public class StableHttpHostResolver extends DefaultHttpHostResolver {

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/TypeConversionTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/TypeConversionTarget.java
@@ -39,6 +39,9 @@ import java.util.Locale;
 import java.util.UUID;
 
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @Dict({
     "0", "-1", "1",
@@ -162,9 +165,6 @@ public class TypeConversionTarget {
         ConversionService.SHARED.convert(value, targetType);
         APP_CTX_CONVERSION_SERVICE.convert(value, targetType);
     }
-
-
-
 
     public static void main(String[] args) {
         LocalJazzerRunner.create(TypeConversionTarget.class).fuzz();

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/UriMatchTemplateTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/UriMatchTemplateTarget.java
@@ -21,6 +21,9 @@ import io.micronaut.fuzzing.FuzzTarget;
 import io.micronaut.fuzzing.HttpDict;
 import io.micronaut.http.uri.UriMatchTemplate;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 @Dict({
@@ -83,6 +86,7 @@ public class UriMatchTemplateTarget {
                 nested.getVariableNames();
                 nested.getVariables();
             }
+            default -> throw new IllegalStateException("Unexpected scenario: " + scenario);
         }
     }
 }

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/sanitizer/ByteBufArraySanitizer.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/sanitizer/ByteBufArraySanitizer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing.sanitizer;
 
 import com.code_intelligence.jazzer.api.FuzzerSecurityIssueCritical;
@@ -9,16 +24,19 @@ import java.lang.ref.SoftReference;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Tracks guarded byte arrays and reports out-of-bounds access detected through rewritten bytecode.
+ */
 @Internal
 public final class ByteBufArraySanitizer {
-    private static final AtomicInteger next = new AtomicInteger();
-    private static final Slot[] slots = new Slot[256];
+    private static final AtomicInteger NEXT = new AtomicInteger();
+    private static final Slot[] SLOTS = new Slot[256];
 
     private static final byte PATTERN_B1 = (byte) 0xd1;
 
     static {
-        for (int i = 0; i < slots.length; i++) {
-            slots[i] = new Slot();
+        for (int i = 0; i < SLOTS.length; i++) {
+            SLOTS[i] = new Slot();
         }
     }
 
@@ -52,7 +70,7 @@ public final class ByteBufArraySanitizer {
         if (guard[0] != PATTERN_B1 || guard.length < 2) {
             return null;
         }
-        Slot slot = slots[guard[1] & 0xff];
+        Slot slot = SLOTS[guard[1] & 0xff];
         SoftReference<byte[]> ref = slot.guard;
         if (ref == null || ref.get() != guard) {
             return null;
@@ -79,10 +97,10 @@ public final class ByteBufArraySanitizer {
         byte[] guard = new byte[array.length];
         guard[0] = PATTERN_B1;
 
-        int i = next.getAndIncrement();
+        int i = NEXT.getAndIncrement();
         guard[1] = (byte) i;
 
-        Slot slot = slots[i % slots.length];
+        Slot slot = SLOTS[i % SLOTS.length];
         slot.backing = array;
         slot.guard = new SoftReference<>(guard);
         slot.start = offset;
@@ -125,8 +143,7 @@ public final class ByteBufArraySanitizer {
         if (slot != null) {
             int start = slot.start;
             int end = slot.end;
-            // Validate [pos, pos+len) within [start, end)
-            long hi = (long) pos + (long) len; // avoid overflow surprises
+            long hi = (long) pos + (long) len;
             if (pos < start || hi > end) {
                 Jazzer.reportFindingFromHook(new FuzzerSecurityIssueCritical("Out-of-bounds array access"));
             }
@@ -136,7 +153,7 @@ public final class ByteBufArraySanitizer {
         }
     }
 
-    private static class Slot {
+    private static final class Slot {
         byte[] backing;
         int start;
         int end;

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/sanitizer/SanitizerTransformer.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/sanitizer/SanitizerTransformer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing.sanitizer;
 
 import net.bytebuddy.agent.builder.AgentBuilder;
@@ -14,6 +29,9 @@ import java.lang.reflect.Method;
 import java.security.ProtectionDomain;
 import java.util.List;
 
+/**
+ * Byte Buddy transformer that rewrites byte-array access patterns for sanitizer checks.
+ */
 public class SanitizerTransformer implements AgentBuilder.Transformer {
     @Override
     public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder, TypeDescription typeDescription, ClassLoader classLoader, JavaModule javaModule, ProtectionDomain protectionDomain) {

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/sanitizer/TestOutOfBoundsTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/sanitizer/TestOutOfBoundsTarget.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing.sanitizer;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -6,6 +21,9 @@ import io.micronaut.fuzzing.runner.LocalJazzerRunner;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget(enableImplicitly = false)
 public class TestOutOfBoundsTarget {
     static {

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/sanitizer/VisitorWrapperImpl.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/sanitizer/VisitorWrapperImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.fuzzing.sanitizer;
 
 import io.netty.buffer.ByteBuf;
@@ -17,6 +32,9 @@ import net.bytebuddy.pool.TypePool;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
+/**
+ * ASM visitor wrapper that redirects selected byte-array operations to sanitizer helpers.
+ */
 final class VisitorWrapperImpl extends AsmVisitorWrapper.AbstractBase {
     private static final String BOOLEAN_ARRAY = "[Z";
 

--- a/fuzzing-tests/src/main/java/io/netty/handler/HandlerFuzzerBase.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/HandlerFuzzerBase.java
@@ -1,19 +1,18 @@
-// Copyright 2024 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-////////////////////////////////////////////////////////////////////////////////
-
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler;
 
 import io.micronaut.fuzzing.EmbeddedChannelFuzzerBase;

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -12,6 +27,9 @@ import io.netty.util.CharsetUtil;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class DelimiterBasedFrameDecoderFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/FixedLengthFrameDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/FixedLengthFrameDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -10,6 +25,9 @@ import io.netty.handler.HandlerFuzzerBase;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class FixedLengthFrameDecoderFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -10,6 +25,9 @@ import io.netty.handler.HandlerFuzzerBase;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class LengthFieldBasedFrameDecoderFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/LineBasedFrameDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/LineBasedFrameDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -10,6 +25,9 @@ import io.netty.handler.HandlerFuzzerBase;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class LineBasedFrameDecoderFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/base64/Base64DecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/base64/Base64DecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.base64;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -11,6 +26,9 @@ import io.netty.handler.codec.DecoderException;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class Base64DecoderFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/BrotliDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/BrotliDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.compression;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -7,6 +22,9 @@ import io.micronaut.fuzzing.runner.LocalJazzerRunner;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class BrotliDecoderFuzzer extends DecompressorFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/Bzip2DecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/Bzip2DecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.compression;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -8,6 +23,9 @@ import io.netty.handler.codec.DecoderException;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class Bzip2DecoderFuzzer extends DecompressorFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/DecompressorFuzzerBase.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/DecompressorFuzzerBase.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.compression;
 
 import io.netty.handler.HandlerFuzzerBase;

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/FastLzFrameDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/FastLzFrameDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.compression;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -8,6 +23,9 @@ import io.netty.handler.codec.DecoderException;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class FastLzFrameDecoderFuzzer extends DecompressorFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/JZlibDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/JZlibDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.compression;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -7,6 +22,9 @@ import io.micronaut.fuzzing.runner.LocalJazzerRunner;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class JZlibDecoderFuzzer extends DecompressorFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.compression;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -7,6 +22,9 @@ import io.micronaut.fuzzing.runner.LocalJazzerRunner;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class JdkZlibDecoderFuzzer extends DecompressorFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.compression;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -7,6 +22,9 @@ import io.micronaut.fuzzing.runner.LocalJazzerRunner;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class Lz4FrameDecoderFuzzer extends DecompressorFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/LzfDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/LzfDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.compression;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -7,6 +22,9 @@ import io.micronaut.fuzzing.runner.LocalJazzerRunner;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class LzfDecoderFuzzer extends DecompressorFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.compression;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -8,6 +23,9 @@ import io.netty.handler.codec.DecoderException;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class SnappyFrameDecoderFuzzer extends DecompressorFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/ZstdDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/ZstdDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.compression;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -7,6 +22,9 @@ import io.micronaut.fuzzing.runner.LocalJazzerRunner;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class ZstdDecoderFuzzer extends DecompressorFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpClientCodecFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpClientCodecFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.http;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -8,6 +23,9 @@ import io.netty.handler.HandlerFuzzerBase;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class HttpClientCodecFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandlerFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandlerFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.http;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -13,6 +28,9 @@ import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class HttpClientUpgradeHandlerFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpContentDecompressorFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpContentDecompressorFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.http;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -11,6 +26,9 @@ import io.netty.handler.codec.compression.DecompressionException;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class HttpContentDecompressorFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpObjectAggregatorFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpObjectAggregatorFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.http;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -12,6 +27,9 @@ import io.netty.handler.codec.PrematureChannelClosureException;
 import javax.net.ssl.SSLException;
 import java.nio.channels.ClosedChannelException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class HttpObjectAggregatorFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpRequestDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpRequestDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.http;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -8,6 +23,9 @@ import io.netty.handler.HandlerFuzzerBase;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class HttpRequestDecoderFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpResponseDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpResponseDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.http;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -8,6 +23,9 @@ import io.netty.handler.HandlerFuzzerBase;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class HttpResponseDecoderFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpServerCodecFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpServerCodecFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.http;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -8,6 +23,9 @@ import io.netty.handler.HandlerFuzzerBase;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class HttpServerCodecFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpServerExpectContinueHandlerFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpServerExpectContinueHandlerFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.http;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -8,6 +23,9 @@ import io.netty.handler.HandlerFuzzerBase;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class HttpServerExpectContinueHandlerFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpServerKeepAliveHandlerFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpServerKeepAliveHandlerFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.http;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -8,6 +23,9 @@ import io.netty.handler.HandlerFuzzerBase;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class HttpServerKeepAliveHandlerFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.http;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -14,6 +29,9 @@ import io.netty.util.AsciiString;
 import javax.net.ssl.SSLException;
 import java.nio.channels.ClosedChannelException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class HttpServerUpgradeHandlerFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/cors/CorsHandlerFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/cors/CorsHandlerFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.http.cors;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -9,6 +24,9 @@ import io.netty.handler.codec.http.HttpServerCodec;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class CorsHandlerFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.http.websocketx;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -14,6 +29,9 @@ import io.netty.handler.codec.http.HttpServerCodec;
 import javax.net.ssl.SSLException;
 import java.nio.channels.ClosedChannelException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class WebSocketServerProtocolHandlerFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http2/Http2FrameCodecFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http2/Http2FrameCodecFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.http2;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -8,6 +23,9 @@ import io.netty.handler.HandlerFuzzerBase;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class Http2FrameCodecFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/json/JsonObjectDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/json/JsonObjectDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.json;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -10,6 +25,9 @@ import io.netty.handler.codec.TooLongFrameException;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class JsonObjectDecoderFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/rtsp/RtspDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/rtsp/RtspDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.rtsp;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -8,6 +23,9 @@ import io.netty.handler.HandlerFuzzerBase;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class RtspDecoderFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/string/StringDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/string/StringDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.string;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -13,6 +28,9 @@ import io.netty.handler.codec.TooLongFrameException;
 import javax.net.ssl.SSLException;
 import java.nio.charset.StandardCharsets;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class StringDecoderFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/xml/XmlFrameDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/xml/XmlFrameDecoderFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.codec.xml;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -12,6 +27,9 @@ import io.netty.handler.codec.TooLongFrameException;
 
 import javax.net.ssl.SSLException;
 
+/**
+ * Fuzzing support type.
+ */
 @FuzzTarget
 @HttpDict
 public class XmlFrameDecoderFuzzer extends HandlerFuzzerBase {

--- a/fuzzing-tests/src/main/java/io/netty/handler/ssl/SslHandlerFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/ssl/SslHandlerFuzzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.netty.handler.ssl;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -14,8 +29,11 @@ import io.netty.util.ReferenceCountUtil;
 import javax.net.ssl.SSLException;
 import java.security.cert.CertificateException;
 
+/**
+ * Fuzz target for Netty's SSL handler.
+ */
 @FuzzTarget
-public class SslHandlerFuzzer extends HandlerFuzzerBase implements AutoCloseable {
+public final class SslHandlerFuzzer extends HandlerFuzzerBase implements AutoCloseable {
     private static final SelfSignedCertificate CERTIFICATE;
 
     static {
@@ -28,23 +46,23 @@ public class SslHandlerFuzzer extends HandlerFuzzerBase implements AutoCloseable
 
     private final SslContext context;
 
-    private static boolean flag(long input, int i) {
-        return ((input >>> i) & 1) != 0;
-    }
-
     private SslHandlerFuzzer(FuzzedDataProvider fuzzedDataProvider) throws SSLException {
         byte flags = fuzzedDataProvider.consumeByte();
         SslProvider provider = SslProvider.JDK;
         boolean startTls = flag(flags, 1);
         context = (flag(flags, 5) ? SslContextBuilder.forServer(CERTIFICATE.key(), CERTIFICATE.cert()) : SslContextBuilder.forClient())
-                .sslProvider(provider)
-                .startTls(startTls)
-                .enableOcsp(flag(flags, 2) && provider != SslProvider.JDK)
-                .clientAuth(flag(flags, 3) ? ClientAuth.REQUIRE : flag(flags, 4) ? ClientAuth.OPTIONAL : ClientAuth.NONE)
-                .build();
+            .sslProvider(provider)
+            .startTls(startTls)
+            .enableOcsp(flag(flags, 2) && provider != SslProvider.JDK)
+            .clientAuth(flag(flags, 3) ? ClientAuth.REQUIRE : flag(flags, 4) ? ClientAuth.OPTIONAL : ClientAuth.NONE)
+            .build();
         channel.pipeline()
-                .addLast(flag(flags, 6) ? context.newHandler(channel.alloc()) : new SslHandler(context.newEngine(channel.alloc()), startTls))
-                .addLast(new ErrorHandler());
+            .addLast(flag(flags, 6) ? context.newHandler(channel.alloc()) : new SslHandler(context.newEngine(channel.alloc()), startTls))
+            .addLast(new ErrorHandler());
+    }
+
+    private static boolean flag(long input, int i) {
+        return ((input >>> i) & 1) != 0;
     }
 
     public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) throws SSLException {


### PR DESCRIPTION
## Summary
- add missing license headers to fuzzing test support and target classes
- normalize Netty fuzzer header style with the rest of the project
- include Checkstyle-only cleanup called out while splitting #189, such as Javadocs, final helper classes, declaration ordering, switch defaults, and brace/spacing fixes

## Verification
- `./gradlew spotlessCheck -q`
- `./gradlew :micronaut-fuzzing-tests:checkstyleMain --continue`
- `./gradlew :micronaut-fuzzing-tests:compileJava -q`

Split from #189.