### PR TITLE
Avoid Jackson collection metadata parsing in fuzz targets

### DIFF
--- a/build-logic/src/main/java/io/micronaut/build/internal/tasks/GenerateModelClasses.java
+++ b/build-logic/src/main/java/io/micronaut/build/internal/tasks/GenerateModelClasses.java
@@ -49,14 +49,13 @@ public abstract class GenerateModelClasses extends DefaultTask {
 import java.io.OutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import io.micronaut.core.annotation.Internal;
 
 @Internal
 public record DefinedFuzzTarget(
     String targetClass,
-    List<String> dictionary,
-    List<String> dictionaryResources,
+    String[] dictionary,
+    String[] dictionaryResources,
     boolean enableImplicitly
 ) {
     public static final String DIRECTORY = "io.micronaut.fuzzing.fuzz-targets";

--- a/fuzzing-annotation-processor/src/main/java/io/micronaut/fuzzing/processor/FuzzTargetVisitor.java
+++ b/fuzzing-annotation-processor/src/main/java/io/micronaut/fuzzing/processor/FuzzTargetVisitor.java
@@ -61,8 +61,8 @@ public class FuzzTargetVisitor implements TypeElementVisitor<FuzzTarget, FuzzTar
             }
             targets.add(new DefinedFuzzTarget(
                 element.getName(),
-                manualDict.isEmpty() ? null : manualDict,
-                dictResources.isEmpty() ? null : dictResources,
+                manualDict.isEmpty() ? null : manualDict.toArray(String[]::new),
+                dictResources.isEmpty() ? null : dictResources.toArray(String[]::new),
                 element.booleanValue(FuzzTarget.class, "enableImplicitly").orElse(true)
             ));
         }

--- a/fuzzing-annotation-processor/src/test/groovy/io/micronaut/fuzzing/processor/FuzzTargetVisitorSpec.groovy
+++ b/fuzzing-annotation-processor/src/test/groovy/io/micronaut/fuzzing/processor/FuzzTargetVisitorSpec.groovy
@@ -1,6 +1,5 @@
 package io.micronaut.fuzzing.processor
 
-import tools.jackson.core.type.TypeReference
 import tools.jackson.databind.ObjectMapper
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 
@@ -22,8 +21,7 @@ class Example {
 }
 """)
         def value = cl.getResources("META-INF/" + DefinedFuzzTarget.DIRECTORY).nextElement().openStream().withCloseable { stream ->
-            mapper.readValue(stream, new TypeReference<List<DefinedFuzzTarget>>() {
-            })
+            mapper.readValue(stream, DefinedFuzzTarget[])
         }
         then:
         value.size() == 1
@@ -49,13 +47,12 @@ class Example {
 }
 """)
         def value = cl.getResources("META-INF/" + DefinedFuzzTarget.DIRECTORY).nextElement().openStream().withCloseable { stream ->
-            mapper.readValue(stream, new TypeReference<List<DefinedFuzzTarget>>() {
-            })
+            mapper.readValue(stream, DefinedFuzzTarget[])
         }
         then:
         value.size() == 1
         when:
-        def single = value.get(0)
+        def single = value[0]
         then:
         single.dictionary().contains("foo")
     }

--- a/jazzer-plugin/build.gradle.kts
+++ b/jazzer-plugin/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
 
     testImplementation(mnTest.junit.jupiter.api)
     testImplementation(mnTest.junit.jupiter.engine)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks {

--- a/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/BaseJazzerTask.java
+++ b/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/BaseJazzerTask.java
@@ -1,6 +1,5 @@
 package io.micronaut.fuzzing.jazzer;
 
-import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 import io.micronaut.fuzzing.model.DefinedFuzzTarget;
 import org.gradle.api.DefaultTask;
@@ -71,8 +70,7 @@ public abstract class BaseJazzerTask extends DefaultTask {
                     List<Path> files = stream.toList();
                     for (Path file : files) {
                         try (InputStream inputStream = Files.newInputStream(file)) {
-                            definedFuzzTargets.addAll(objectMapper.readValue(inputStream, new TypeReference<List<DefinedFuzzTarget>>() {
-                            }));
+                            definedFuzzTargets.addAll(List.of(objectMapper.readValue(inputStream, DefinedFuzzTarget[].class)));
                         }
                     }
                 }


### PR DESCRIPTION
This fixes the OSS-Fuzz build failure caused by Jackson 3 databind hitting the `JsonFormat.Shape.POJO` code path while Gradle's runtime provides an older bundled `jackson-annotations` jar.

The fuzz target metadata model is generated only for this plugin and does not need Java collection-like target types. Switching the generated metadata fields from `List<String>` to `String[]` keeps the JSON shape as arrays and keeps ObjectMapper-based Jackson databind parsing, while avoiding the collection-like deserializer path that requires `Shape.POJO`.

Changes:
- Generate fuzz target metadata model fields as `String[]` instead of `List<String>`.
- Write metadata arrays from the annotation processor.
- Read metadata files as `DefinedFuzzTarget[]` in the Jazzer plugin.
- Add the JUnit Platform launcher to the included Jazzer plugin test runtime for Gradle 9.5.

Validation:
- `./gradlew :micronaut-fuzzing-annotation-processor:test --no-daemon --stacktrace`
- `./gradlew -p jazzer-plugin compileJava test --no-daemon --stacktrace`
- `OUT=/tmp/micronaut-fuzzing-oss-out ./gradlew --max-workers 2 micronaut-fuzzing-tests:prepareClusterFuzz --no-daemon --stacktrace`
- `./gradlew :micronaut-fuzzing-tests:check --no-daemon --stacktrace`
- `git diff --check`

Resolves #202