### PR TITLE
Support OSS-Fuzz coverage classfile compatibility

### DIFF
--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -108,6 +108,7 @@ tasks.withType<PrepareClusterFuzzTask> {
         "--enable-preview"
     )
     javaHome.set("\$this_dir/jdk")
+    coverageClassFileMajorVersion.set(68)
 }
 
 tasks.named<JazzerTask>("jazzer") {

--- a/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/BaseJazzerTask.java
+++ b/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/BaseJazzerTask.java
@@ -8,6 +8,7 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Classpath;
+import org.gradle.work.DisableCachingByDefault;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
@@ -30,6 +31,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@DisableCachingByDefault(because = "Fuzzing tasks execute external fuzzing tools and prepare OSS-Fuzz directories")
 public abstract class BaseJazzerTask extends DefaultTask {
     private final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/JazzerPlugin.java
+++ b/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/JazzerPlugin.java
@@ -61,6 +61,7 @@ public abstract class JazzerPlugin implements Plugin<Project> {
             task.setDescription("Prepare run scripts of the different fuzz targets for ClusterFuzz (OSS-Fuzz) execution");
 
             task.getClasspath().setFrom(jazzerBaseClasspath);
+            task.getOutputDirectory().convention(project.getLayout().getBuildDirectory().dir("cluster-fuzz"));
             task.getSourcePath().setFrom(jazzerBaseClasspath.getIncoming().artifactView(v -> {
                 v.withVariantReselection();
                 v.attributes(attributes -> {

--- a/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/JazzerTask.java
+++ b/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/JazzerTask.java
@@ -9,8 +9,11 @@ import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
+import org.gradle.work.DisableCachingByDefault;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -22,8 +25,10 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
+@DisableCachingByDefault(because = "Runs Jazzer as an external fuzzing process")
 public abstract class JazzerTask extends BaseJazzerTask {
     @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
     @Optional
     public abstract DirectoryProperty getCorpus();
 
@@ -36,11 +41,13 @@ public abstract class JazzerTask extends BaseJazzerTask {
     public abstract Property<Integer> getJobs();
 
     @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
     @Nonnull
     @Optional
     public abstract RegularFileProperty getMinimizeCrashFile();
 
     @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
     @Nonnull
     @Optional
     public abstract RegularFileProperty getReproduceCrashFile();

--- a/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTask.java
+++ b/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTask.java
@@ -6,6 +6,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Nested;
@@ -15,6 +16,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.gradle.work.DisableCachingByDefault;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -34,6 +36,7 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -42,11 +45,13 @@ import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@DisableCachingByDefault(because = "Prepares OSS-Fuzz output directories and executable wrapper scripts")
 public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
     private static final Logger LOG = LoggerFactory.getLogger(PrepareClusterFuzzTask.class);
 
     @InputFiles
     @Nonnull
+    @Classpath
     public abstract ConfigurableFileCollection getSourcePath();
 
     @OutputDirectory
@@ -75,6 +80,14 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
     @Input
     @Optional
     public abstract Property<String> getSetupScript();
+
+    /**
+     * Maximum class file major version to write to OSS-Fuzz coverage sources. This does not affect
+     * the classpath used to execute fuzz targets.
+     */
+    @Input
+    @Optional
+    public abstract Property<Integer> getCoverageClassFileMajorVersion();
 
     /**
      * Introspector-specific settings. Note that these don't affect the actual fuzzing, only the
@@ -318,6 +331,7 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
 
             ClassNameMatcher introspectorIncludes = compileIntrospectorIncludes();
             ClassNameMatcher introspectorExcludes = compileIntrospectorExcludes();
+            Integer coverageClassFileMajorVersion = validateCoverageClassFileMajorVersion();
             classRoots.walkFileTree(classRoot -> new SimpleFileVisitor<>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
@@ -330,7 +344,11 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
                             Files.createDirectories(classDest.getParent());
                         } catch (FileAlreadyExistsException ignored) {
                         }
-                        Files.copy(file, classDest, StandardCopyOption.REPLACE_EXISTING);
+                        if (coverageClassFileMajorVersion == null) {
+                            Files.copy(file, classDest, StandardCopyOption.REPLACE_EXISTING);
+                        } else {
+                            Files.write(classDest, limitClassFileMajorVersion(Files.readAllBytes(file), coverageClassFileMajorVersion));
+                        }
 
                         String sourceName = classRelative.toString();
                         sourceName = sourceName.substring(0, sourceName.length() - ".class".length()) + ".java";
@@ -344,6 +362,32 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
             });
 
         }
+    }
+
+    private Integer validateCoverageClassFileMajorVersion() {
+        Integer majorVersion = getCoverageClassFileMajorVersion().getOrNull();
+        if (majorVersion != null && (majorVersion <= 0 || majorVersion > 0xffff)) {
+            throw new IllegalArgumentException("coverageClassFileMajorVersion must be between 1 and 65535");
+        }
+        return majorVersion;
+    }
+
+    static byte[] limitClassFileMajorVersion(byte[] classFile, int maxMajorVersion) {
+        if (classFile.length < 8 ||
+            classFile[0] != (byte) 0xca ||
+            classFile[1] != (byte) 0xfe ||
+            classFile[2] != (byte) 0xba ||
+            classFile[3] != (byte) 0xbe) {
+            return classFile;
+        }
+        int majorVersion = ((classFile[6] & 0xff) << 8) | (classFile[7] & 0xff);
+        if (majorVersion <= maxMajorVersion) {
+            return classFile;
+        }
+        byte[] compatible = Arrays.copyOf(classFile, classFile.length);
+        compatible[6] = (byte) (maxMajorVersion >>> 8);
+        compatible[7] = (byte) maxMajorVersion;
+        return compatible;
     }
 
     public interface Introspector {

--- a/jazzer-plugin/src/test/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTaskTest.java
+++ b/jazzer-plugin/src/test/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTaskTest.java
@@ -6,7 +6,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PrepareClusterFuzzTaskTest {
@@ -78,4 +80,56 @@ class PrepareClusterFuzzTaskTest {
         assertEquals(names.size(), Set.copyOf(names.values()).size(),
             "all assigned names must be unique");
     }
+
+    @Test
+    void capsCoverageClassFileMajorVersion() {
+        byte[] classFile = minimalClassFile(69);
+
+        byte[] compatible = PrepareClusterFuzzTask.limitClassFileMajorVersion(classFile, 68);
+
+        assertEquals(68, classFileMajorVersion(compatible));
+        assertEquals(69, classFileMajorVersion(classFile));
+    }
+
+    @Test
+    void leavesEqualClassFileVersionUnchanged() {
+        byte[] classFile = minimalClassFile(68);
+
+        byte[] compatible = PrepareClusterFuzzTask.limitClassFileMajorVersion(classFile, 68);
+
+        assertArrayEquals(classFile, compatible);
+        assertSame(classFile, compatible);
+    }
+
+    @Test
+    void leavesOlderClassFileVersionUnchanged() {
+        byte[] classFile = minimalClassFile(61);
+
+        byte[] compatible = PrepareClusterFuzzTask.limitClassFileMajorVersion(classFile, 68);
+
+        assertArrayEquals(classFile, compatible);
+        assertSame(classFile, compatible);
+    }
+
+    @Test
+    void leavesNonClassFileBytesUnchanged() {
+        byte[] bytes = new byte[] {1, 2, 3, 4};
+
+        byte[] compatible = PrepareClusterFuzzTask.limitClassFileMajorVersion(bytes, 68);
+
+        assertArrayEquals(bytes, compatible);
+        assertSame(bytes, compatible);
+    }
+
+    private static byte[] minimalClassFile(int majorVersion) {
+        byte[] classFile = new byte[] {(byte) 0xca, (byte) 0xfe, (byte) 0xba, (byte) 0xbe, 0, 0, 0, 0};
+        classFile[6] = (byte) (majorVersion >>> 8);
+        classFile[7] = (byte) majorVersion;
+        return classFile;
+    }
+
+    private static int classFileMajorVersion(byte[] classFile) {
+        return ((classFile[6] & 0xff) << 8) | (classFile[7] & 0xff);
+    }
+
 }


### PR DESCRIPTION
## Summary
- add an opt-in `coverageClassFileMajorVersion` setting for `PrepareClusterFuzzTask`
- cap only the classfile major version of copied OSS-Fuzz coverage classes under `$OUT/src`
- leave runtime jars and fuzz execution classpaths unchanged
- satisfy Gradle plugin validation for Jazzer task types and provide a default local output directory

## Verification
- `./gradlew :micronaut-jazzer-plugin:check -q`
- `./gradlew :micronaut-fuzzing-tests:prepareClusterFuzz -q`
- `OUT=/tmp/mn-fuzzing-oss-out ./gradlew :micronaut-fuzzing-tests:prepareClusterFuzz -q`
- byte-level check: coverage copies capped at major versions `{61: 295, 68: 1990}` while runtime `micronaut-fuzzing-tests-0.2.0-SNAPSHOT.jar` still contains Java 25 classes `{61: 12, 69: 93}`
- `./gradlew spotlessApply check -q -x japiCmp`

Resolves #205