### PR TITLE
Cap Jazzer dumped coverage classes

### DIFF
--- a/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTask.java
+++ b/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTask.java
@@ -183,16 +183,15 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
                 // not when running inside oss-fuzz...
                 line.add("'--jvm_args=" + getJvmArgs().get().stream().map(s -> s.replace(":", "\\:")).collect(Collectors.joining(":")) + "'");
                 line.add("$@");
-                String command = String.join(" ", line);
-                if (coverageClassFileMajorVersion != null) {
-                    command += "\n" + coverageClassFileMajorVersionScript(coverageClassFileMajorVersion);
-                }
                 String sh = """
                 #!/bin/bash
                 # LLVMFuzzerTestOneInput <-- for fuzzer detection (see test_all.py)
                 this_dir=$(dirname "$0")
                 export EXTERNAL_JAZZER_ARGS="$@"
-                """ + getSetupScript().getOrElse("") + "\n" + command;
+                """ + getSetupScript().getOrElse("") + "\n" + String.join(" ", line);
+                if (coverageClassFileMajorVersion != null) {
+                    sh += "\n" + coverageClassFileMajorVersionScript(coverageClassFileMajorVersion);
+                }
                 Path targetPath = getOutputDirectory().file(fileName).get().getAsFile().toPath();
                 Files.writeString(targetPath, sh);
                 Files.setPosixFilePermissions(targetPath, Set.of(

--- a/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTask.java
+++ b/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTask.java
@@ -143,6 +143,7 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
         }
 
         try (ClasspathAccess classpathAccess = new ClasspathAccess()) {
+            Integer coverageClassFileMajorVersion = validateCoverageClassFileMajorVersion();
             List<DefinedFuzzTarget> targets = findFuzzTargets(classpathAccess);
             Map<String, String> targetNames = assignTargetNames(targets.stream().map(DefinedFuzzTarget::targetClass).toList());
             for (DefinedFuzzTarget target : targets) {
@@ -182,12 +183,16 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
                 // not when running inside oss-fuzz...
                 line.add("'--jvm_args=" + getJvmArgs().get().stream().map(s -> s.replace(":", "\\:")).collect(Collectors.joining(":")) + "'");
                 line.add("$@");
+                String command = String.join(" ", line);
+                if (coverageClassFileMajorVersion != null) {
+                    command += "\n" + coverageClassFileMajorVersionScript(coverageClassFileMajorVersion);
+                }
                 String sh = """
                 #!/bin/bash
                 # LLVMFuzzerTestOneInput <-- for fuzzer detection (see test_all.py)
                 this_dir=$(dirname "$0")
                 export EXTERNAL_JAZZER_ARGS="$@"
-                """ + getSetupScript().getOrElse("") + "\n" + String.join(" ", line);
+                """ + getSetupScript().getOrElse("") + "\n" + command;
                 Path targetPath = getOutputDirectory().file(fileName).get().getAsFile().toPath();
                 Files.writeString(targetPath, sh);
                 Files.setPosixFilePermissions(targetPath, Set.of(
@@ -362,6 +367,49 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
             });
 
         }
+    }
+
+    static String coverageClassFileMajorVersionScript(int maxMajorVersion) {
+        return """
+            jazzer_status=$?
+            dump_classes_dirs=()
+            while [[ $# -gt 0 ]]; do
+                case "$1" in
+                    --dump_classes_dir=*|-dump_classes_dir=*)
+                        dump_classes_dirs+=("${1#*=}")
+                        ;;
+                    --dump_classes_dir|-dump_classes_dir)
+                        shift
+                        if [[ $# -gt 0 ]]; then
+                            dump_classes_dirs+=("$1")
+                        fi
+                        ;;
+                esac
+                shift
+            done
+            if [[ ${#dump_classes_dirs[@]} -gt 0 ]]; then
+                python3 - "%d" "${dump_classes_dirs[@]}" <<'PY'
+            import pathlib
+            import sys
+
+            max_major_version = int(sys.argv[1])
+            for dump_classes_dir in sys.argv[2:]:
+                root = pathlib.Path(dump_classes_dir)
+                if not root.exists():
+                    continue
+                for class_file in root.rglob("*.class"):
+                    data = bytearray(class_file.read_bytes())
+                    if len(data) < 8 or data[:4] != bytes((0xca, 0xfe, 0xba, 0xbe)):
+                        continue
+                    major_version = (data[6] << 8) | data[7]
+                    if major_version > max_major_version:
+                        data[6] = (max_major_version >> 8) & 0xff
+                        data[7] = max_major_version & 0xff
+                        class_file.write_bytes(data)
+            PY
+            fi
+            exit "$jazzer_status"
+            """.formatted(maxMajorVersion);
     }
 
     private Integer validateCoverageClassFileMajorVersion() {

--- a/jazzer-plugin/src/test/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTaskTest.java
+++ b/jazzer-plugin/src/test/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTaskTest.java
@@ -121,6 +121,17 @@ class PrepareClusterFuzzTaskTest {
         assertSame(bytes, compatible);
     }
 
+    @Test
+    void coverageClassFileMajorVersionScriptHandlesJazzerDumpClassesDir() {
+        String script = PrepareClusterFuzzTask.coverageClassFileMajorVersionScript(68);
+
+        assertTrue(script.contains("jazzer_status=$?"));
+        assertTrue(script.contains("--dump_classes_dir=*|-dump_classes_dir=*"));
+        assertTrue(script.contains("--dump_classes_dir|-dump_classes_dir"));
+        assertTrue(script.contains("python3 - \"68\""));
+        assertTrue(script.contains("exit \"$jazzer_status\""));
+    }
+
     private static byte[] minimalClassFile(int majorVersion) {
         byte[] classFile = new byte[] {(byte) 0xca, (byte) 0xfe, (byte) 0xba, (byte) 0xbe, 0, 0, 0, 0};
         classFile[6] = (byte) (majorVersion >>> 8);


### PR DESCRIPTION
## Summary
- post-process Jazzer `--dump_classes_dir` output in generated OSS-Fuzz wrappers when `coverageClassFileMajorVersion` is enabled
- cap dumped `.class` file major versions after Jazzer exits, before OSS-Fuzz/JaCoCo analyzes `/out/dumps/*_classes`
- preserve Jazzer's original exit status and keep runtime classpath artifacts unchanged

## Verification
- `./gradlew :micronaut-jazzer-plugin:check -q`
- `OUT=/tmp/mn-fuzzing-oss-out ./gradlew :micronaut-fuzzing-tests:prepareClusterFuzz -q`
- synthetic wrapper test: fake `jazzer_driver` wrote `StringDecoderFuzzer.8af82634c227a9a4.class` with major version 69 into `--dump_classes_dir`; generated wrapper rewrote it to major version 68

Follow-up to #206 for the remaining OSS-Fuzz JaCoCo `/out/dumps/*_classes` failure.

Resolves #205