### PR TITLE
Scan default OSS-Fuzz dump class directories

### DIFF
--- a/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTask.java
+++ b/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTask.java
@@ -386,13 +386,22 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
                 esac
                 shift
             done
+            for fallback_dump_classes_dir in "$this_dir"/dumps/*_classes; do
+                if [[ -d "$fallback_dump_classes_dir" ]]; then
+                    dump_classes_dirs+=("$fallback_dump_classes_dir")
+                fi
+            done
             if [[ ${#dump_classes_dirs[@]} -gt 0 ]]; then
                 python3 - "%d" "${dump_classes_dirs[@]}" <<'PY'
             import pathlib
             import sys
 
             max_major_version = int(sys.argv[1])
+            seen = set()
             for dump_classes_dir in sys.argv[2:]:
+                if dump_classes_dir in seen:
+                    continue
+                seen.add(dump_classes_dir)
                 root = pathlib.Path(dump_classes_dir)
                 if not root.exists():
                     continue

--- a/jazzer-plugin/src/test/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTaskTest.java
+++ b/jazzer-plugin/src/test/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTaskTest.java
@@ -128,6 +128,7 @@ class PrepareClusterFuzzTaskTest {
         assertTrue(script.contains("jazzer_status=$?"));
         assertTrue(script.contains("--dump_classes_dir=*|-dump_classes_dir=*"));
         assertTrue(script.contains("--dump_classes_dir|-dump_classes_dir"));
+        assertTrue(script.contains("$this_dir\"/dumps/*_classes"));
         assertTrue(script.contains("python3 - \"68\""));
         assertTrue(script.contains("exit \"$jazzer_status\""));
     }

--- a/jazzer-plugin/src/test/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTaskTest.java
+++ b/jazzer-plugin/src/test/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTaskTest.java
@@ -121,18 +121,6 @@ class PrepareClusterFuzzTaskTest {
         assertSame(bytes, compatible);
     }
 
-    @Test
-    void coverageClassFileMajorVersionScriptHandlesJazzerDumpClassesDir() {
-        String script = PrepareClusterFuzzTask.coverageClassFileMajorVersionScript(68);
-
-        assertTrue(script.contains("jazzer_status=$?"));
-        assertTrue(script.contains("--dump_classes_dir=*|-dump_classes_dir=*"));
-        assertTrue(script.contains("--dump_classes_dir|-dump_classes_dir"));
-        assertTrue(script.contains("$this_dir\"/dumps/*_classes"));
-        assertTrue(script.contains("python3 - \"68\""));
-        assertTrue(script.contains("exit \"$jazzer_status\""));
-    }
-
     private static byte[] minimalClassFile(int majorVersion) {
         byte[] classFile = new byte[] {(byte) 0xca, (byte) 0xfe, (byte) 0xba, (byte) 0xbe, 0, 0, 0, 0};
         classFile[6] = (byte) (majorVersion >>> 8);


### PR DESCRIPTION
## Summary
- also scan generated wrapper default `dumps/*_classes` directories for coverage classfile version capping
- covers OSS-Fuzz/JaCoCo failures where dump directories appear under `/out/dumps/*_classes` but are not visible as `--dump_classes_dir` wrapper arguments
- removes the weak generated-script string assertion test; behavior is verified with a generated-wrapper reproduction instead

## Verification
- `./gradlew :micronaut-jazzer-plugin:check -q`
- `OUT=/tmp/mn-fuzzing-oss-out ./gradlew :micronaut-fuzzing-tests:prepareClusterFuzz -q`
- synthetic wrapper fallback test: fake `jazzer_driver` wrote `HttpServerCodecFuzzer.cb2c189700b66c2b.class` with major version 69 into `$OUT/dumps/HttpServerCodecFuzzer_classes`; generated wrapper rewrote it to major version 68 without a `--dump_classes_dir` argument

Follow-up to #207 for the remaining OSS-Fuzz JaCoCo `/out/dumps/*_classes` failure.

Resolves #205