### PR TITLE
Bundle newer JaCoCo for OSS-Fuzz coverage

### DIFF
--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -11,6 +11,8 @@ repositories {
     mavenCentral()
 }
 
+val ossFuzzJacoco by configurations.creating
+
 micronautBuild {
     javaVersion.set(25)
 }
@@ -53,6 +55,9 @@ tasks.named("check") {
 group = "io.micronaut.fuzzing"
 
 dependencies {
+    ossFuzzJacoco("org.jacoco:org.jacoco.agent:0.8.14:runtime")
+    ossFuzzJacoco("org.jacoco:org.jacoco.cli:0.8.14:nodeps")
+
     implementation(mn.micronaut.http.server.netty)
     implementation(mn.netty.contrib.multipart.core)
     implementation(mn.micronaut.jackson.databind)
@@ -108,7 +113,27 @@ tasks.withType<PrepareClusterFuzzTask> {
         "--enable-preview"
     )
     javaHome.set("\$this_dir/jdk")
-    coverageClassFileMajorVersion.set(68)
+    doFirst {
+        project.copy {
+            from(ossFuzzJacoco)
+            into(outputDirectory.dir("jacoco").get().asFile)
+        }
+    }
+    val dollar = "$"
+    setupScript.set("""
+        if [[ "${dollar}EXTERNAL_JAZZER_ARGS" == *"/opt/jacoco-agent.jar"* ]]; then
+            jacoco_agent=$(find "${dollar}this_dir/jacoco" -maxdepth 1 -name 'org.jacoco.agent-*-runtime.jar' -print -quit)
+            jacoco_cli=$(find "${dollar}this_dir/jacoco" -maxdepth 1 -name 'org.jacoco.cli-*-nodeps.jar' -print -quit)
+            if [[ -z "${dollar}jacoco_agent" || -z "${dollar}jacoco_cli" ]]; then
+                echo "Missing bundled JaCoCo jars in ${dollar}this_dir/jacoco" >&2
+                exit 1
+            fi
+            cp "${dollar}jacoco_agent" "/opt/jacoco-agent.jar.${dollar}${dollar}"
+            mv "/opt/jacoco-agent.jar.${dollar}${dollar}" /opt/jacoco-agent.jar
+            cp "${dollar}jacoco_cli" "/opt/jacoco-cli.jar.${dollar}${dollar}"
+            mv "/opt/jacoco-cli.jar.${dollar}${dollar}" /opt/jacoco-cli.jar
+        fi
+    """.trimIndent())
 }
 
 tasks.named<JazzerTask>("jazzer") {

--- a/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTask.java
+++ b/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTask.java
@@ -36,7 +36,6 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -80,14 +79,6 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
     @Input
     @Optional
     public abstract Property<String> getSetupScript();
-
-    /**
-     * Maximum class file major version to write to OSS-Fuzz coverage sources. This does not affect
-     * the classpath used to execute fuzz targets.
-     */
-    @Input
-    @Optional
-    public abstract Property<Integer> getCoverageClassFileMajorVersion();
 
     /**
      * Introspector-specific settings. Note that these don't affect the actual fuzzing, only the
@@ -143,7 +134,6 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
         }
 
         try (ClasspathAccess classpathAccess = new ClasspathAccess()) {
-            Integer coverageClassFileMajorVersion = validateCoverageClassFileMajorVersion();
             List<DefinedFuzzTarget> targets = findFuzzTargets(classpathAccess);
             Map<String, String> targetNames = assignTargetNames(targets.stream().map(DefinedFuzzTarget::targetClass).toList());
             for (DefinedFuzzTarget target : targets) {
@@ -189,9 +179,6 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
                 this_dir=$(dirname "$0")
                 export EXTERNAL_JAZZER_ARGS="$@"
                 """ + getSetupScript().getOrElse("") + "\n" + String.join(" ", line);
-                if (coverageClassFileMajorVersion != null) {
-                    sh += "\n" + coverageClassFileMajorVersionScript(coverageClassFileMajorVersion);
-                }
                 Path targetPath = getOutputDirectory().file(fileName).get().getAsFile().toPath();
                 Files.writeString(targetPath, sh);
                 Files.setPosixFilePermissions(targetPath, Set.of(
@@ -335,7 +322,6 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
 
             ClassNameMatcher introspectorIncludes = compileIntrospectorIncludes();
             ClassNameMatcher introspectorExcludes = compileIntrospectorExcludes();
-            Integer coverageClassFileMajorVersion = validateCoverageClassFileMajorVersion();
             classRoots.walkFileTree(classRoot -> new SimpleFileVisitor<>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
@@ -348,11 +334,7 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
                             Files.createDirectories(classDest.getParent());
                         } catch (FileAlreadyExistsException ignored) {
                         }
-                        if (coverageClassFileMajorVersion == null) {
-                            Files.copy(file, classDest, StandardCopyOption.REPLACE_EXISTING);
-                        } else {
-                            Files.write(classDest, limitClassFileMajorVersion(Files.readAllBytes(file), coverageClassFileMajorVersion));
-                        }
+                        Files.copy(file, classDest, StandardCopyOption.REPLACE_EXISTING);
 
                         String sourceName = classRelative.toString();
                         sourceName = sourceName.substring(0, sourceName.length() - ".class".length()) + ".java";
@@ -366,84 +348,6 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
             });
 
         }
-    }
-
-    static String coverageClassFileMajorVersionScript(int maxMajorVersion) {
-        return """
-            jazzer_status=$?
-            dump_classes_dirs=()
-            while [[ $# -gt 0 ]]; do
-                case "$1" in
-                    --dump_classes_dir=*|-dump_classes_dir=*)
-                        dump_classes_dirs+=("${1#*=}")
-                        ;;
-                    --dump_classes_dir|-dump_classes_dir)
-                        shift
-                        if [[ $# -gt 0 ]]; then
-                            dump_classes_dirs+=("$1")
-                        fi
-                        ;;
-                esac
-                shift
-            done
-            for fallback_dump_classes_dir in "$this_dir"/dumps/*_classes; do
-                if [[ -d "$fallback_dump_classes_dir" ]]; then
-                    dump_classes_dirs+=("$fallback_dump_classes_dir")
-                fi
-            done
-            if [[ ${#dump_classes_dirs[@]} -gt 0 ]]; then
-                python3 - "%d" "${dump_classes_dirs[@]}" <<'PY'
-            import pathlib
-            import sys
-
-            max_major_version = int(sys.argv[1])
-            seen = set()
-            for dump_classes_dir in sys.argv[2:]:
-                if dump_classes_dir in seen:
-                    continue
-                seen.add(dump_classes_dir)
-                root = pathlib.Path(dump_classes_dir)
-                if not root.exists():
-                    continue
-                for class_file in root.rglob("*.class"):
-                    data = bytearray(class_file.read_bytes())
-                    if len(data) < 8 or data[:4] != bytes((0xca, 0xfe, 0xba, 0xbe)):
-                        continue
-                    major_version = (data[6] << 8) | data[7]
-                    if major_version > max_major_version:
-                        data[6] = (max_major_version >> 8) & 0xff
-                        data[7] = max_major_version & 0xff
-                        class_file.write_bytes(data)
-            PY
-            fi
-            exit "$jazzer_status"
-            """.formatted(maxMajorVersion);
-    }
-
-    private Integer validateCoverageClassFileMajorVersion() {
-        Integer majorVersion = getCoverageClassFileMajorVersion().getOrNull();
-        if (majorVersion != null && (majorVersion <= 0 || majorVersion > 0xffff)) {
-            throw new IllegalArgumentException("coverageClassFileMajorVersion must be between 1 and 65535");
-        }
-        return majorVersion;
-    }
-
-    static byte[] limitClassFileMajorVersion(byte[] classFile, int maxMajorVersion) {
-        if (classFile.length < 8 ||
-            classFile[0] != (byte) 0xca ||
-            classFile[1] != (byte) 0xfe ||
-            classFile[2] != (byte) 0xba ||
-            classFile[3] != (byte) 0xbe) {
-            return classFile;
-        }
-        int majorVersion = ((classFile[6] & 0xff) << 8) | (classFile[7] & 0xff);
-        if (majorVersion <= maxMajorVersion) {
-            return classFile;
-        }
-        byte[] compatible = Arrays.copyOf(classFile, classFile.length);
-        compatible[6] = (byte) (maxMajorVersion >>> 8);
-        compatible[7] = (byte) maxMajorVersion;
-        return compatible;
     }
 
     public interface Introspector {

--- a/jazzer-plugin/src/test/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTaskTest.java
+++ b/jazzer-plugin/src/test/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTaskTest.java
@@ -6,9 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PrepareClusterFuzzTaskTest {
@@ -81,55 +79,5 @@ class PrepareClusterFuzzTaskTest {
             "all assigned names must be unique");
     }
 
-    @Test
-    void capsCoverageClassFileMajorVersion() {
-        byte[] classFile = minimalClassFile(69);
-
-        byte[] compatible = PrepareClusterFuzzTask.limitClassFileMajorVersion(classFile, 68);
-
-        assertEquals(68, classFileMajorVersion(compatible));
-        assertEquals(69, classFileMajorVersion(classFile));
-    }
-
-    @Test
-    void leavesEqualClassFileVersionUnchanged() {
-        byte[] classFile = minimalClassFile(68);
-
-        byte[] compatible = PrepareClusterFuzzTask.limitClassFileMajorVersion(classFile, 68);
-
-        assertArrayEquals(classFile, compatible);
-        assertSame(classFile, compatible);
-    }
-
-    @Test
-    void leavesOlderClassFileVersionUnchanged() {
-        byte[] classFile = minimalClassFile(61);
-
-        byte[] compatible = PrepareClusterFuzzTask.limitClassFileMajorVersion(classFile, 68);
-
-        assertArrayEquals(classFile, compatible);
-        assertSame(classFile, compatible);
-    }
-
-    @Test
-    void leavesNonClassFileBytesUnchanged() {
-        byte[] bytes = new byte[] {1, 2, 3, 4};
-
-        byte[] compatible = PrepareClusterFuzzTask.limitClassFileMajorVersion(bytes, 68);
-
-        assertArrayEquals(bytes, compatible);
-        assertSame(bytes, compatible);
-    }
-
-    private static byte[] minimalClassFile(int majorVersion) {
-        byte[] classFile = new byte[] {(byte) 0xca, (byte) 0xfe, (byte) 0xba, (byte) 0xbe, 0, 0, 0, 0};
-        classFile[6] = (byte) (majorVersion >>> 8);
-        classFile[7] = (byte) majorVersion;
-        return classFile;
-    }
-
-    private static int classFileMajorVersion(byte[] classFile) {
-        return ((classFile[6] & 0xff) << 8) | (classFile[7] & 0xff);
-    }
 
 }


### PR DESCRIPTION
## Summary
- stop relying on classfile header downgrading for OSS-Fuzz coverage compatibility
- bundle JaCoCo 0.8.14 in the OSS-Fuzz output and install it from generated wrappers only for coverage runs that use `/opt/jacoco-agent.jar`
- keep runtime and coverage class files as Java 25 instead of pretending they are an older classfile version

## Upstream context
Current `google/oss-fuzz` `infra/base-images/base-runner/Dockerfile` still installs JaCoCo 0.8.7 at `/opt/jacoco-agent.jar` and `/opt/jacoco-cli.jar`. JaCoCo 0.8.7 predates Java 25 classfile support; JaCoCo 0.8.14 officially supports Java 25.

## Verification
- `./gradlew :micronaut-jazzer-plugin:check -q`
- `OUT=/tmp/mn-fuzzing-oss-out ./gradlew :micronaut-fuzzing-tests:prepareClusterFuzz -q`
- generated output includes JaCoCo 0.8.14 jars under `$OUT/jacoco`
- generated wrapper replaces `/opt/jacoco-agent.jar` and `/opt/jacoco-cli.jar` with bundled jars when coverage args reference `/opt/jacoco-agent.jar`
- JaCoCo 0.8.14 `classinfo` successfully parses `HttpResponseDecoderFuzzer.class` with Java 25 classfile major 69
- generated coverage class files remain Java 25 where applicable (`$OUT/src` majors include 69)

Follow-up to #208 after confirming classfile header downgrading is not safe for Java 25 to Java 17 compatibility.

Resolves #205