### PR TITLE
Enable trace logging for context setup

### DIFF
--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/bind/JsonBeanPropertyBinderTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/bind/JsonBeanPropertyBinderTarget.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.fuzzing.bind;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.BeanProvider;
@@ -33,6 +35,7 @@ import io.micronaut.fuzzing.runner.LocalJazzerRunner;
 import io.micronaut.json.JsonConfiguration;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.json.bind.JsonBeanPropertyBinderExceptionHandler;
+import org.slf4j.LoggerFactory;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -60,14 +63,22 @@ public class JsonBeanPropertyBinderTarget {
     private static final BeanPropertyBinder BINDER;
 
     static {
+        setLogLevel("io.micronaut", Level.TRACE);
+
         ApplicationContext ctx = ApplicationContext.run(Map.of());
         JsonMapper jsonMapper = ctx.getBean(JsonMapper.class);
         JsonConfiguration jsonConfig = ctx.getBean(JsonConfiguration.class);
         BeanProvider<JsonBeanPropertyBinderExceptionHandler> handlers =
             ctx.getBean(Argument.of(BeanProvider.class, JsonBeanPropertyBinderExceptionHandler.class));
         BINDER = new JsonBeanPropertyBinder(jsonMapper, jsonConfig, handlers);
+
+        setLogLevel("io.micronaut", Level.WARN);
     }
 
+    private static void setLogLevel(String loggerName, Level level) {
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        loggerContext.getLogger(loggerName).setLevel(level);
+    }
     public static void fuzzerTestOneInput(FuzzedDataProvider data) {
         int entryCount = data.consumeInt(1, 8);
         Map<String, Object> params = new LinkedHashMap<>();

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/bind/JsonBeanPropertyBinderTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/bind/JsonBeanPropertyBinderTarget.java
@@ -79,6 +79,7 @@ public class JsonBeanPropertyBinderTarget {
         LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
         loggerContext.getLogger(loggerName).setLevel(level);
     }
+
     public static void fuzzerTestOneInput(FuzzedDataProvider data) {
         int entryCount = data.consumeInt(1, 8);
         Map<String, Object> params = new LinkedHashMap<>();

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/EmbeddedHttpTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/EmbeddedHttpTarget.java
@@ -22,6 +22,8 @@ import io.micronaut.fuzzing.EmbeddedChannelFuzzerBase;
 import io.micronaut.fuzzing.FuzzTarget;
 import io.micronaut.fuzzing.HttpDict;
 import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
 import io.micronaut.http.server.netty.NettyHttpServer;
 import io.micronaut.runtime.server.EmbeddedServer;
 import org.slf4j.LoggerFactory;
@@ -78,9 +80,16 @@ public class EmbeddedHttpTarget extends EmbeddedChannelFuzzerBase {
             System.setProperty("VM_NAME", vmName);
             LoggerFactory.getLogger(EmbeddedHttpTarget.class).info("Starting embedded HTTP target. VM name is: {}", vmName);
 
+            setLogLevel("io.micronaut", Level.TRACE);
             ApplicationContext ctx = ApplicationContext.run(cfg);
+            setLogLevel("io.micronaut", Level.WARN);
 
             nettyHttpServer = (NettyHttpServer) ctx.getBean(EmbeddedServer.class);
+        }
+
+        private static void setLogLevel(String loggerName, Level level) {
+            LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+            loggerContext.getLogger(loggerName).setLevel(level);
         }
     }
 }

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/TypeConversionTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/TypeConversionTarget.java
@@ -15,12 +15,15 @@
  */
 package io.micronaut.fuzzing.http;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.fuzzing.Dict;
 import io.micronaut.fuzzing.FuzzTarget;
 import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.math.BigDecimal;
@@ -121,8 +124,13 @@ import java.util.UUID;
 })
 public class TypeConversionTarget {
 
-    private static final ConversionService APP_CTX_CONVERSION_SERVICE =
-        ApplicationContext.run().getBean(ConversionService.class);
+    private static final ConversionService appCtxConversionService;
+
+    static {
+        setLogLevel("io.micronaut", Level.TRACE);
+        appCtxConversionService = ApplicationContext.run().getBean(ConversionService.class);
+        setLogLevel("io.micronaut", Level.WARN);
+    }
 
     private static final Class<?>[] TARGET_TYPES = {
         Integer.class,
@@ -157,13 +165,19 @@ public class TypeConversionTarget {
         File.class,
     };
 
+    private static void setLogLevel(String loggerName, Level level) {
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        loggerContext.getLogger(loggerName).setLevel(level);
+    }
+
+
     public static void fuzzerTestOneInput(FuzzedDataProvider data) {
         int typeIndex = data.consumeInt(0, TARGET_TYPES.length - 1);
         Class<?> targetType = TARGET_TYPES[typeIndex];
         String value = data.consumeRemainingAsString();
 
         ConversionService.SHARED.convert(value, targetType);
-        APP_CTX_CONVERSION_SERVICE.convert(value, targetType);
+        appCtxConversionService.convert(value, targetType);
     }
 
     public static void main(String[] args) {

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/TypeConversionTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/TypeConversionTarget.java
@@ -124,11 +124,11 @@ import java.util.UUID;
 })
 public class TypeConversionTarget {
 
-    private static final ConversionService appCtxConversionService;
+    private static final ConversionService APP_CTX_CONVERSION_SERVICE;
 
     static {
         setLogLevel("io.micronaut", Level.TRACE);
-        appCtxConversionService = ApplicationContext.run().getBean(ConversionService.class);
+        APP_CTX_CONVERSION_SERVICE = ApplicationContext.run().getBean(ConversionService.class);
         setLogLevel("io.micronaut", Level.WARN);
     }
 
@@ -170,14 +170,13 @@ public class TypeConversionTarget {
         loggerContext.getLogger(loggerName).setLevel(level);
     }
 
-
     public static void fuzzerTestOneInput(FuzzedDataProvider data) {
         int typeIndex = data.consumeInt(0, TARGET_TYPES.length - 1);
         Class<?> targetType = TARGET_TYPES[typeIndex];
         String value = data.consumeRemainingAsString();
 
         ConversionService.SHARED.convert(value, targetType);
-        appCtxConversionService.convert(value, targetType);
+        APP_CTX_CONVERSION_SERVICE.convert(value, targetType);
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
This PR enables trace logging during context initialization to capture startup diagnostics, then disables it before the first fuzz test runs