### PR TITLE
Add fuzz targets for JSON deserialization and HTTP cookie parsing

### DIFF
--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/CookieParsingTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/CookieParsingTarget.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.micronaut.fuzzing.http;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import io.micronaut.fuzzing.Dict;
@@ -25,23 +26,19 @@ import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
 
 import java.util.Collection;
 
-
 @FuzzTarget
 @Dict({
     "session=abc123",
     "theme=dark",
     "id=42",
 
-
     "session=abc123; theme=dark",
     "a=1; b=2; c=3",
-
 
     "name=value; Path=/; HttpOnly",
     "name=value; Secure; SameSite=Strict",
     "name=value; Domain=example.com; Max-Age=3600",
     "name=value; Expires=Thu, 01 Jan 2099 00:00:00 GMT",
-
 
     "=",
     "a=",
@@ -67,6 +64,7 @@ public class CookieParsingTarget {
             case 2 -> encodeDecodeRoundTrip(data);
         }
     }
+
     private static void decodeStrict(FuzzedDataProvider data) {
         String header = data.consumeRemainingAsString();
         try {
@@ -78,6 +76,7 @@ public class CookieParsingTarget {
         } catch (IllegalArgumentException ignored) {
         }
     }
+
     private static void decodeLax(FuzzedDataProvider data) {
         String header = data.consumeRemainingAsString();
         try {
@@ -89,8 +88,9 @@ public class CookieParsingTarget {
         } catch (IllegalArgumentException ignored) {
         }
     }
+
     private static void encodeDecodeRoundTrip(FuzzedDataProvider data) {
-        String name  = data.consumeString(32);
+        String name = data.consumeString(32);
         String value = data.consumeString(64);
         String encoded;
         try {
@@ -102,10 +102,7 @@ public class CookieParsingTarget {
         ServerCookieDecoder.STRICT.decode(encoded);
     }
 
-
+    public static void main(String[] args) {
+        LocalJazzerRunner.create(CookieParsingTarget.class).fuzz();
+    }
 }
-
-public static void main(String[] args) {
-    LocalJazzerRunner.create(CookieParsingTarget.class).fuzz();
-}
-

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/CookieParsingTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/CookieParsingTarget.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import io.micronaut.fuzzing.Dict;
+import io.micronaut.fuzzing.FuzzTarget;
+import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.DefaultCookie;
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
+import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
+
+import java.util.Collection;
+
+
+@FuzzTarget
+@Dict({
+    "session=abc123",
+    "theme=dark",
+    "id=42",
+
+
+    "session=abc123; theme=dark",
+    "a=1; b=2; c=3",
+
+
+    "name=value; Path=/; HttpOnly",
+    "name=value; Secure; SameSite=Strict",
+    "name=value; Domain=example.com; Max-Age=3600",
+    "name=value; Expires=Thu, 01 Jan 2099 00:00:00 GMT",
+
+
+    "=",
+    "a=",
+    "=b",
+    ";",
+    ";;",
+    "name=v1; name=v2",
+    "\"quoted\"=value",
+    "name=\"quoted value\"",
+
+    "name=\t",
+    " name=value",
+    "name =value",
+    "name= value",
+})
+public class CookieParsingTarget {
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        int scenario = data.consumeInt(0, 3);
+        switch (scenario) {
+            case 0 -> decodeStrict(data);
+            case 1 -> decodeLax(data);
+            case 2 -> encodeDecodeRoundTrip(data);
+        }
+    }
+    private static void decodeStrict(FuzzedDataProvider data) {
+        String header = data.consumeRemainingAsString();
+        try {
+            Collection<Cookie> cookies = ServerCookieDecoder.STRICT.decode(header);
+            for (Cookie c : cookies) {
+                c.name();
+                c.value();
+            }
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+    private static void decodeLax(FuzzedDataProvider data) {
+        String header = data.consumeRemainingAsString();
+        try {
+            Collection<Cookie> cookies = ServerCookieDecoder.LAX.decode(header);
+            for (Cookie c : cookies) {
+                c.name();
+                c.value();
+            }
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+    private static void encodeDecodeRoundTrip(FuzzedDataProvider data) {
+        String name  = data.consumeString(32);
+        String value = data.consumeString(64);
+        String encoded;
+        try {
+            DefaultCookie cookie = new DefaultCookie(name, value);
+            encoded = ServerCookieEncoder.STRICT.encode(cookie);
+        } catch (IllegalArgumentException ignored) {
+            return;
+        }
+        ServerCookieDecoder.STRICT.decode(encoded);
+    }
+
+
+}
+
+public static void main(String[] args) {
+    LocalJazzerRunner.create(CookieParsingTarget.class).fuzz();
+}
+

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/JsonDeserializationTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/JsonDeserializationTarget.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.fuzzing.http;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.type.Argument;
+import io.micronaut.fuzzing.Dict;
+import io.micronaut.fuzzing.FuzzTarget;
+import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import io.micronaut.json.JsonMapper;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Fuzz target for JSON deserialization via Micronaut's JsonMapper.
+ */
+@FuzzTarget
+@Dict({
+    "{", "}", "[", "]", ":", ",", "\"",
+
+    "null", "true", "false",
+
+    "\"keyword\":", "\"page\":", "\"active\":",
+
+    "{}", "[]", "\"\"",
+    "{\"keyword\":\"test\",\"page\":1,\"active\":true}",
+
+
+    "{\"a\":", "[[[[", "]]]]", "}}}}",
+
+
+    "999999999999999999999999999999",
+    "-999999999999999999999999999999",
+    "1e9999",
+    "1.0e-9999",
+
+
+    "\"\\u0000\"",
+    "\"\\n\\r\\t\"",
+    "\"\\uD800\\uDFFF\"",
+
+
+    "{\"a\":1,\"a\":2}",
+
+    "{}garbage",
+    "[]extra",
+})
+public class JsonDeserializationTarget {
+
+    private static final JsonMapper JSON_MAPPER;
+
+    static {
+        JSON_MAPPER = ApplicationContext.run(Map.of()).getBean(JsonMapper.class);
+    }
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) throws Exception {
+        byte[] raw = data.consumeRemainingAsBytes();
+        int scenario = raw.length > 0 ? (raw[0] & 0xFF) % 3 : 0;
+        byte[] json  = raw.length > 1 ? Arrays.copyOfRange(raw, 1, raw.length) : new byte[0];
+
+        switch (scenario) {
+            case 0 -> deserializeToMap(json);
+            case 1 -> deserializeToPojo(json);
+            case 2 -> deserializeToList(json);
+            default -> { }
+        }
+    }
+
+    private static void deserializeToMap(byte[] json) {
+        try {
+            Map<?, ?> map = JSON_MAPPER.readValue(json, Argument.mapOf(String.class, Object.class));
+            if (map != null) {
+                map.values().forEach(v -> {
+                    if (v != null) {
+                        v.toString();
+                    }
+                });
+            }
+        } catch (IOException | IllegalArgumentException ignored) {
+        }
+    }
+
+    private static void deserializeToPojo(byte[] json) {
+        try {
+            SearchQuery q = JSON_MAPPER.readValue(json, Argument.of(SearchQuery.class));
+            if (q != null) {
+                JSON_MAPPER.writeValueAsBytes(q);
+            }
+        } catch (IOException | IllegalArgumentException ignored) {
+        }
+    }
+
+    private static void deserializeToList(byte[] json) {
+        try {
+            List<?> list = JSON_MAPPER.readValue(json, Argument.listOf(Object.class));
+            if (list != null) {
+                list.forEach(v -> {
+                    if (v != null) {
+                        v.toString();
+                    }
+                });
+            }
+        } catch (IOException | IllegalArgumentException ignored) {
+        }
+    }
+
+    public static void main(String[] args) {
+        LocalJazzerRunner.create(JsonDeserializationTarget.class).fuzz();
+    }
+}

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/JsonDeserializationTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/JsonDeserializationTarget.java
@@ -42,20 +42,16 @@ import java.util.Map;
     "{}", "[]", "\"\"",
     "{\"keyword\":\"test\",\"page\":1,\"active\":true}",
 
-
     "{\"a\":", "[[[[", "]]]]", "}}}}",
-
 
     "999999999999999999999999999999",
     "-999999999999999999999999999999",
     "1e9999",
     "1.0e-9999",
 
-
     "\"\\u0000\"",
     "\"\\n\\r\\t\"",
     "\"\\uD800\\uDFFF\"",
-
 
     "{\"a\":1,\"a\":2}",
 
@@ -73,13 +69,14 @@ public class JsonDeserializationTarget {
     public static void fuzzerTestOneInput(FuzzedDataProvider data) throws Exception {
         byte[] raw = data.consumeRemainingAsBytes();
         int scenario = raw.length > 0 ? (raw[0] & 0xFF) % 3 : 0;
-        byte[] json  = raw.length > 1 ? Arrays.copyOfRange(raw, 1, raw.length) : new byte[0];
+        byte[] json = raw.length > 1 ? Arrays.copyOfRange(raw, 1, raw.length) : new byte[0];
 
         switch (scenario) {
             case 0 -> deserializeToMap(json);
             case 1 -> deserializeToPojo(json);
             case 2 -> deserializeToList(json);
-            default -> { }
+            default -> {
+            }
         }
     }
 

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/SimpleController.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/SimpleController.java
@@ -28,6 +28,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.annotation.CookieValue;
 import io.micronaut.http.annotation.Part;
 import io.micronaut.http.annotation.RequestBean;
+import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.multipart.CompletedFileUpload;
 import java.util.List;
 import jakarta.inject.Singleton;
@@ -62,6 +63,9 @@ public final class SimpleController {
     static final String UPLOAD_MULTIPLE = "/upload-multiple";
     static final String ECHO_NEGOTIATED = "/echo-negotiated";
     static final String ECHO_MULTI_ACCEPT = "/echo-multi-accept";
+    static final String ECHO_SET_COOKIE    = "/echo-set-cookie";
+    static final String ECHO_MULTI_QUERY   = "/echo-multi-query";
+    static final String ECHO_JSON_OBJECT   = "/echo-json-object";
 
     @Get
     public String index() {
@@ -179,6 +183,21 @@ public final class SimpleController {
     @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN})
     public HttpResponse<String> echoMultiAccept(@Body @Nullable String body) {
         return HttpResponse.ok(body != null ? body : "empty");
+    }
+    @Get(ECHO_SET_COOKIE + "{?value}")
+    public HttpResponse<String> echoSetCookie(@QueryValue @Nullable String value) {
+        return HttpResponse.<String>ok("ok")
+            .cookie(Cookie.of("fuzz-cookie", value != null ? value : "default"));
+    }
+    @Get(ECHO_MULTI_QUERY)
+    public String echoMultiQuery(@QueryValue @Nullable List<String> tag) {
+        return tag == null ? "none" : String.join(",", tag);
+    }
+    @Post(ECHO_JSON_OBJECT)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public SearchQuery echoJsonObject(@Body SearchQuery query) {
+        return query;
     }
 
 }

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/SimpleController.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/SimpleController.java
@@ -15,28 +15,29 @@
  */
 package io.micronaut.fuzzing.http;
 
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Consumes;
 import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.CookieValue;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.Part;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.annotation.QueryValue;
-import io.micronaut.core.annotation.Nullable;
-import io.micronaut.http.annotation.CookieValue;
-import io.micronaut.http.annotation.Part;
 import io.micronaut.http.annotation.RequestBean;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.multipart.CompletedFileUpload;
-import java.util.List;
 import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
-import io.micronaut.http.annotation.Produces;
-import static io.micronaut.http.MediaType.MULTIPART_FORM_DATA;
-import io.micronaut.http.HttpResponse;
 
+import java.util.List;
+
+import static io.micronaut.http.MediaType.MULTIPART_FORM_DATA;
 
 /**
  * Simple HTTP endpoints used by fuzzing tests.
@@ -63,9 +64,9 @@ public final class SimpleController {
     static final String UPLOAD_MULTIPLE = "/upload-multiple";
     static final String ECHO_NEGOTIATED = "/echo-negotiated";
     static final String ECHO_MULTI_ACCEPT = "/echo-multi-accept";
-    static final String ECHO_SET_COOKIE    = "/echo-set-cookie";
-    static final String ECHO_MULTI_QUERY   = "/echo-multi-query";
-    static final String ECHO_JSON_OBJECT   = "/echo-json-object";
+    static final String ECHO_SET_COOKIE = "/echo-set-cookie";
+    static final String ECHO_MULTI_QUERY = "/echo-multi-query";
+    static final String ECHO_JSON_OBJECT = "/echo-json-object";
 
     @Get
     public String index() {
@@ -184,15 +185,18 @@ public final class SimpleController {
     public HttpResponse<String> echoMultiAccept(@Body @Nullable String body) {
         return HttpResponse.ok(body != null ? body : "empty");
     }
+
     @Get(ECHO_SET_COOKIE + "{?value}")
     public HttpResponse<String> echoSetCookie(@QueryValue @Nullable String value) {
         return HttpResponse.<String>ok("ok")
             .cookie(Cookie.of("fuzz-cookie", value != null ? value : "default"));
     }
+
     @Get(ECHO_MULTI_QUERY)
     public String echoMultiQuery(@QueryValue @Nullable List<String> tag) {
         return tag == null ? "none" : String.join(",", tag);
     }
+
     @Post(ECHO_JSON_OBJECT)
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)

--- a/fuzzing-tests/src/test/java/io/micronaut/fuzzing/http/SimpleControllerTest.java
+++ b/fuzzing-tests/src/test/java/io/micronaut/fuzzing/http/SimpleControllerTest.java
@@ -231,4 +231,77 @@ class SimpleControllerTest {
 
         Assertions.assertEquals("count:1", response);
     }
+    @Test
+    void echoSetCookieWithValue() {
+        HttpResponse<String> response = client.toBlocking().exchange(
+            HttpRequest.GET(SimpleController.ECHO_SET_COOKIE + "?value=hello"),
+            String.class);
+        Assertions.assertEquals(HttpStatus.OK, response.getStatus());
+        String setCookie = response.header("Set-Cookie");
+        Assertions.assertNotNull(setCookie, "Set-Cookie header must be present");
+        Assertions.assertTrue(setCookie.contains("hello"), "cookie value must contain supplied string");
+    }
+
+    @Test
+    void echoSetCookieDefaultWhenAbsent() {
+        HttpResponse<String> response = client.toBlocking().exchange(
+            HttpRequest.GET(SimpleController.ECHO_SET_COOKIE),
+            String.class);
+        Assertions.assertEquals(HttpStatus.OK, response.getStatus());
+        String setCookie = response.header("Set-Cookie");
+        Assertions.assertNotNull(setCookie);
+        Assertions.assertTrue(setCookie.contains("default"));
+    }
+
+    @Test
+    void echoMultiQueryTwoValues() {
+        String body = client.toBlocking().retrieve(
+            HttpRequest.GET(SimpleController.ECHO_MULTI_QUERY + "?tag=foo&tag=bar"));
+        Assertions.assertEquals("foo,bar", body);
+    }
+
+    @Test
+    void echoMultiQuerySingleValue() {
+        String body = client.toBlocking().retrieve(
+            HttpRequest.GET(SimpleController.ECHO_MULTI_QUERY + "?tag=only"));
+        Assertions.assertEquals("only", body);
+    }
+
+    @Test
+    void echoMultiQueryAbsent() {
+        String body = client.toBlocking().retrieve(
+            HttpRequest.GET(SimpleController.ECHO_MULTI_QUERY));
+        Assertions.assertEquals("none", body);
+    }
+
+    @Test
+    void echoJsonObjectRoundTrip() {
+        String body = client.toBlocking().retrieve(
+            HttpRequest.POST(SimpleController.ECHO_JSON_OBJECT,
+                    "{\"keyword\":\"micronaut\",\"page\":2,\"active\":true}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+        Assertions.assertTrue(body.contains("micronaut"));
+        Assertions.assertTrue(body.contains("2"));
+    }
+
+    @Test
+    void echoJsonObjectEmptyBody() {
+        HttpResponse<String> response = client.toBlocking().exchange(
+            HttpRequest.POST(SimpleController.ECHO_JSON_OBJECT, "{}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON),
+            String.class);
+        Assertions.assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    @Test
+    void echoJsonObjectNullFields() {
+        String body = client.toBlocking().retrieve(
+            HttpRequest.POST(SimpleController.ECHO_JSON_OBJECT,
+                    "{\"keyword\":null,\"page\":null,\"active\":null}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+        Assertions.assertNotNull(body);
+    }
 }

--- a/fuzzing-tests/src/test/java/io/micronaut/fuzzing/http/SimpleControllerTest.java
+++ b/fuzzing-tests/src/test/java/io/micronaut/fuzzing/http/SimpleControllerTest.java
@@ -231,6 +231,7 @@ class SimpleControllerTest {
 
         Assertions.assertEquals("count:1", response);
     }
+
     @Test
     void echoSetCookieWithValue() {
         HttpResponse<String> response = client.toBlocking().exchange(
@@ -278,7 +279,7 @@ class SimpleControllerTest {
     void echoJsonObjectRoundTrip() {
         String body = client.toBlocking().retrieve(
             HttpRequest.POST(SimpleController.ECHO_JSON_OBJECT,
-                    "{\"keyword\":\"micronaut\",\"page\":2,\"active\":true}")
+                "{\"keyword\":\"micronaut\",\"page\":2,\"active\":true}")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON));
         Assertions.assertTrue(body.contains("micronaut"));
@@ -299,7 +300,7 @@ class SimpleControllerTest {
     void echoJsonObjectNullFields() {
         String body = client.toBlocking().retrieve(
             HttpRequest.POST(SimpleController.ECHO_JSON_OBJECT,
-                    "{\"keyword\":null,\"page\":null,\"active\":null}")
+                "{\"keyword\":null,\"page\":null,\"active\":null}")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON));
         Assertions.assertNotNull(body);


### PR DESCRIPTION
New fuzz targets:

JsonDeserializationTarget — fuzzes JsonMapper across map, POJO, and list deserialization with edge-case JSON inputs 
CookieParsingTarget — fuzzes Netty's ServerCookieDecoder in STRICT and LAX modes, plus encode→decode round-trip via ServerCookieEncoder
SimpleController additions:

GET /echo-set-cookie — returns a Set-Cookie response header (supports fuzz coverage of cookie serialization)
GET /echo-multi-query — echoes repeated query parameters as a list
POST /echo-json-object — JSON round-trip endpoint for SearchQuery
SimpleControllerTest additions:

Tests for all three new endpoints covering present/absent params, default values, and null fields