### PR TITLE
Fix LZ4 frame decoder fuzz regression

### DIFF
--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -1,5 +1,6 @@
 import io.micronaut.fuzzing.jazzer.JazzerTask
 import io.micronaut.fuzzing.jazzer.PrepareClusterFuzzTask
+import io.micronaut.fuzzing.jazzer.JazzerRegressionTask
 import java.time.Duration
 
 plugins {
@@ -30,6 +31,30 @@ tasks.named<Test>("test") {
     exclude("io/micronaut/fuzzing/sanitizer/SanitizerTransformerTest.class")
 }
 
+val lz4FrameDecoderRegression by tasks.registering(JazzerRegressionTask::class) {
+    description = "Runs the LZ4 frame decoder OSS-Fuzz regression input."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+    targets.set(setOf("io.netty.handler.codec.compression.Lz4FrameDecoderFuzzer"))
+    jvmArgs.set(listOf(
+        "-Dio.netty.customResourceLeakDetector=io.netty.util.LeakPresenceDetector",
+        "-Dio.netty.leakDetection.targetRecords=0",
+        "--enable-preview"
+    ))
+    base64RegressionInputs.put("oss-fuzz-4644981624340480", """
+        TFo0QmxvY2spggAAAP4AAAAAAAoKU0VQO1NFUHRTRVA7U0VQdKlTRVB0S0NBTEVOJ0RBUgB8RVBT
+        RVBTRVBTRVBTRVBNS0FDVElWSVRZU0VQU0VQU0VQUHJBUgB8RWFnbWFTRVBTRVBTRVBTRSpTRVBT
+        RVBDb25uZWN0aW9uOlNFUFNFUFNFUFNFUFNFUFNFUFNFUFNFUFNTRVBTUFNFUFNFUFNFUFNFUFNF
+        UFNFKlNFUFNFUFNFUFNFUFNFUFNFU0VQU0VQU0VQU0VQU0VQU0VQU0VQU0VQU0VTRVBTRVBTRVBT
+        RWFkZFBTRVBTRVBTRSpTRVBTRVBTRVBTRVAAAAB8RVBTRVBTRVBTRVBTRVBTRVBTRVBTRVBTU0VQ
+        U0VQU0VQU0VQPVNFUFNFUFNFKlNFUFNFUFNFUFNFUFNFUFNFUFNFUFNFUFNFUFNFUFNTRVBTUFNF
+        UFNFUFNTRVBTRVBTRVBTRSpTRVBTRVBTRVBTU+FQU+NFUFNFUFNFUFNFUFNFUFNFUFNFKlNFUCNF
+        UFNFUENFUFNFUFNFUFNFUFNFUFNFUFNFUFNFUFNFUFNFUFNTRVBTRVBTRVBTU0VQU0VQU0VQU0VQ
+        U0VTRVBTRVBTRVBTRVBQRVBFU1NTRVBTU0VQU0VQU0VQUHJhZ21TRVBTRVBTRVBTRVBTRVBTRVBT
+        RVBTRSpFUFNFUFNTRVBTRVBTRVA=
+    """.trimIndent())
+}
+
 val sanitizerTest by tasks.registering(Test::class) {
     description = "Runs sanitizer bytecode transformation tests in an isolated JVM."
     group = LifecycleBasePlugin.VERIFICATION_GROUP
@@ -50,6 +75,7 @@ val sanitizerTest by tasks.registering(Test::class) {
 
 tasks.named("check") {
     dependsOn(sanitizerTest)
+    dependsOn(lz4FrameDecoderRegression)
 }
 
 group = "io.micronaut.fuzzing"
@@ -77,7 +103,7 @@ dependencies {
     runtimeOnly("com.github.luben:zstd-jni:1.5.7-6")
     runtimeOnly("com.jcraft:jzlib:1.1.3")
     runtimeOnly("com.ning:compress-lzf:1.1.3")
-    runtimeOnly("org.lz4:lz4-java:1.8.0")
+    implementation("org.lz4:lz4-java:1.8.0")
     runtimeOnly("org.bouncycastle:bcpkix-jdk18on:1.82")
     implementation("io.netty:netty-codec-xml")
 

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoderFuzzer.java
@@ -19,6 +19,7 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import io.micronaut.fuzzing.FuzzTarget;
 import io.micronaut.fuzzing.HttpDict;
 import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import net.jpountz.lz4.LZ4Factory;
 
 import javax.net.ssl.SSLException;
 
@@ -28,9 +29,22 @@ import javax.net.ssl.SSLException;
 @FuzzTarget
 @HttpDict
 public class Lz4FrameDecoderFuzzer extends DecompressorFuzzerBase {
+    private static final byte[] WARMUP_COMPRESSED_BLOCK = {0x10, 0};
+
     public Lz4FrameDecoderFuzzer(FuzzedDataProvider fuzzedDataProvider) {
+        warmUpLz4();
         channel.pipeline()
             .addLast(new Lz4FrameDecoder(fuzzedDataProvider.consumeBoolean()));
+    }
+
+    private static void warmUpLz4() {
+        // lz4-java can load its native implementation during the first decode. Do that before the timed loop.
+        LZ4Factory.fastestInstance().fastDecompressor()
+            .decompress(WARMUP_COMPRESSED_BLOCK, 0, new byte[1], 0, 1);
+
+        Lz4XXHash32 checksum = new Lz4XXHash32(Lz4Constants.DEFAULT_SEED);
+        checksum.update(new byte[0], 0, 0);
+        checksum.getValue();
     }
 
     public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) throws SSLException {

--- a/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/JazzerPlugin.java
+++ b/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/JazzerPlugin.java
@@ -28,13 +28,13 @@ public abstract class JazzerPlugin implements Plugin<Project> {
         });
         jazzerBaseClasspath.getDependencies().add(project.getDependencies().create(project));
 
-        project.getTasks().register("jazzer", JazzerTask.class, task -> {
-            Configuration jazzerWithRuntimeClasspath = project.getConfigurations().create("jazzerWithRuntimeClasspath", c -> {
-                c.extendsFrom(runtimeClasspath);
-                c.exclude(Map.of("group", "io.micronaut.fuzzing", "module", "micronaut-fuzzing-runner"));
-            });
-            jazzerWithRuntimeClasspath.getDependencies().add(project.getDependencies().create(project));
+        Configuration jazzerWithRuntimeClasspath = project.getConfigurations().create("jazzerWithRuntimeClasspath", c -> {
+            c.extendsFrom(runtimeClasspath);
+            c.exclude(Map.of("group", "io.micronaut.fuzzing", "module", "micronaut-fuzzing-runner"));
+        });
+        jazzerWithRuntimeClasspath.getDependencies().add(project.getDependencies().create(project));
 
+        project.afterEvaluate(p -> {
             // add a dependency on jazzer standalone that matches the jazzer-api version
             String jazzerVersion = null;
             for (ResolvedArtifactResult artifact : runtimeClasspath.getIncoming().getArtifacts()) {
@@ -50,11 +50,22 @@ public abstract class JazzerPlugin implements Plugin<Project> {
             if (jazzerVersion != null) {
                 jazzerWithRuntimeClasspath.getDependencies().add(project.getDependencies().create("com.code-intelligence:jazzer:" + jazzerVersion));
             }
+        });
+
+        project.getTasks().withType(JazzerRegressionTask.class).configureEach(task -> {
+            task.getClasspath().setFrom(jazzerWithRuntimeClasspath);
+        });
+
+        project.getTasks().register("jazzer", JazzerTask.class, task -> {
 
             task.setGroup(LifecycleBasePlugin.CHECK_TASK_NAME);
             task.setDescription("Runs jazzer for fuzzing.");
 
             task.getClasspath().setFrom(jazzerWithRuntimeClasspath);
+        });
+        project.getTasks().register("jazzerRegression", JazzerRegressionTask.class, task -> {
+            task.setGroup(LifecycleBasePlugin.CHECK_TASK_NAME);
+            task.setDescription("Runs Jazzer fuzz targets against configured regression inputs.");
         });
         project.getTasks().register("prepareClusterFuzz", PrepareClusterFuzzTask.class, task -> {
             task.setGroup(LifecycleBasePlugin.ASSEMBLE_TASK_NAME);

--- a/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/JazzerRegressionTask.java
+++ b/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/JazzerRegressionTask.java
@@ -1,0 +1,79 @@
+package io.micronaut.fuzzing.jazzer;
+
+import io.micronaut.fuzzing.model.DefinedFuzzTarget;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.process.ExecOperations;
+import org.gradle.work.DisableCachingByDefault;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+@DisableCachingByDefault(because = "Runs Jazzer against fixed regression inputs")
+public abstract class JazzerRegressionTask extends BaseJazzerTask {
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    @Nonnull
+    public abstract ConfigurableFileCollection getRegressionInputs();
+
+    @Input
+    public abstract MapProperty<String, String> getBase64RegressionInputs();
+
+    @Inject
+    protected abstract ExecOperations getExecOperations();
+
+    @TaskAction
+    public void run() throws IOException {
+        Map<String, String> base64Inputs = getBase64RegressionInputs().getOrElse(Map.of());
+        if (getRegressionInputs().isEmpty() && base64Inputs.isEmpty()) {
+            throw new IllegalStateException("No regression inputs configured");
+        }
+        List<Path> decodedInputs = new ArrayList<>();
+        try (ClasspathAccess classpathAccess = new ClasspathAccess()) {
+            for (Map.Entry<String, String> entry : base64Inputs.entrySet()) {
+                Path input = Files.createTempFile("jazzer-regression-" + entry.getKey() + "-", ".input");
+                decodedInputs.add(input);
+                Files.write(input, Base64.getMimeDecoder().decode(entry.getValue()));
+            }
+            for (DefinedFuzzTarget target : findFuzzTargets(classpathAccess)) {
+                for (File input : getRegressionInputs().getFiles()) {
+                    runJazzer(target, input.toPath());
+                }
+                for (Path input : decodedInputs) {
+                    runJazzer(target, input);
+                }
+            }
+        } finally {
+            for (Path input : decodedInputs) {
+                Files.deleteIfExists(input);
+            }
+        }
+    }
+
+    private void runJazzer(DefinedFuzzTarget target, Path input) {
+        getExecOperations().javaexec(spec -> {
+            List<String> args = new ArrayList<>();
+            collectArgs(args, target);
+            spec.classpath(getClasspath());
+            args.add("--cp=" + getClasspath().getAsPath());
+            args.add(input.toString());
+            spec.jvmArgs(getJvmArgs().getOrElse(List.of()));
+            spec.setArgs(args);
+            spec.getMainClass().set("com.code_intelligence.jazzer.Jazzer");
+            getLogger().quiet("Jazzer regression command line: {}", String.join(" ", spec.getCommandLine()));
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Add a reusable Jazzer regression task for replaying fixed fuzz inputs.
- Replay OSS-Fuzz testcase 4644981624340480 against `Lz4FrameDecoderFuzzer`.
- Warm up `lz4-java` before the measured `EmbeddedChannel` loop to avoid first-use native loading in the CPU budget.

## Verification
- `./gradlew :micronaut-jazzer-plugin:check :micronaut-fuzzing-tests:lz4FrameDecoderRegression -q`
- `./gradlew :micronaut-fuzzing-tests:check -q`
