### PR TITLE
Fix OSS-Fuzz 4768382317821952 reproducer

### DIFF
--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -170,3 +170,22 @@ tasks.named<JazzerTask>("jazzer") {
     maxTotalTime.set(if (collectJfr) Duration.ofMinutes(2) else Duration.ofHours(2))
     //coverageDumpFile.set(layout.buildDirectory.file("cov-report.exec"))
 }
+
+tasks.register<JazzerTask>("reproduceOssFuzz4768382317821952") {
+    description = "Reproduces OSS-Fuzz testcase 4768382317821952 with EmbeddedHttpTarget."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+    classpath.from(tasks.named<JazzerTask>("jazzer").map { it.classpath })
+    targets.set(listOf("io.micronaut.fuzzing.http.EmbeddedHttpTarget"))
+    jvmArgs.set(listOf(
+        "-Xmx512M",
+        "-XX:MaxDirectMemorySize=256M",
+        "-Dio.netty.noUnsafe=true",
+        "-Dio.netty.customResourceLeakDetector=io.netty.util.LeakPresenceDetector",
+        "-Dio.netty.leakDetection.targetRecords=100",
+        "-XX:+ExitOnOutOfMemoryError",
+        "--enable-preview"
+    ))
+    rssLimitMb.set(8192)
+    reproduceCrashFile.set(layout.projectDirectory.file("src/test/resources/oss-fuzz/4768382317821952"))
+}

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/EmbeddedHttpTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/EmbeddedHttpTarget.java
@@ -25,6 +25,9 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import io.micronaut.http.server.netty.NettyHttpServer;
 import io.micronaut.runtime.server.EmbeddedServer;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.ReferenceCountUtil;
 import org.slf4j.LoggerFactory;
 
 import java.lang.management.ManagementFactory;
@@ -65,6 +68,24 @@ public class EmbeddedHttpTarget extends EmbeddedChannelFuzzerBase {
             setLogLevel("io.micronaut", Level.WARN);
 
             nettyHttpServer = (NettyHttpServer) ctx.getBean(EmbeddedServer.class);
+            warmUp(nettyHttpServer);
+        }
+
+        private static void warmUp(NettyHttpServer nettyHttpServer) {
+            EmbeddedChannel channel = nettyHttpServer.buildEmbeddedChannel(false);
+            try {
+                byte[] request = "GET / HTTP/1.1\r\nContent-Length: 0\r\nHost: localhost\r\nConnection: close\r\n\r\n".getBytes(StandardCharsets.UTF_8);
+                ByteBuf buffer = channel.alloc().buffer(request.length);
+                buffer.writeBytes(request);
+                channel.writeInbound(buffer);
+                channel.finish();
+                Object message;
+                while ((message = channel.readOutbound()) != null) {
+                    ReferenceCountUtil.release(message);
+                }
+            } finally {
+                channel.finishAndReleaseAll();
+            }
         }
 
         private static void setLogLevel(String loggerName, Level level) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ micronaut-logging = "1.7.1"
 groovy = "4.0.15"
 spock = "2.3-groovy-4.0"
 
-managed-jazzer = "0.26.0"
+managed-jazzer = "0.30.0"
 
 # Managed versions appear in the BOM
 # managed-somelib = "1.0"


### PR DESCRIPTION
## Summary
- upgrade Jazzer to 0.30.0 to avoid the DefaultConfigurationPath record instrumentation crash
- add a reproducer task and zero-byte OSS-Fuzz testcase for 4768382317821952
- warm up EmbeddedHttpTarget with a minimal request instead of increasing the CPU budget

## Verification
- ./gradlew :micronaut-fuzzing-tests:reproduceOssFuzz4768382317821952 --stacktrace
- ./gradlew :micronaut-fuzzing-tests:sanitizerTest --stacktrace
- ./gradlew :micronaut-fuzzing-tests:jazzer --rerun-tasks --stacktrace
- ./gradlew :micronaut-fuzzing-tests:prepareClusterFuzz --stacktrace