### PR TITLE
Use project-pinned Jazzer for OSS-Fuzz

### DIFF
--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -118,6 +118,8 @@ dependencies {
 }
 
 tasks.withType<PrepareClusterFuzzTask> {
+    jazzerDriver.set("micronaut_jazzer_driver")
+    jazzerAgent.set("micronaut_jazzer_agent_deploy.jar")
     introspector {
         includes = listOf("io.micronaut.*")
         excludes = listOf(

--- a/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/JazzerPlugin.java
+++ b/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/JazzerPlugin.java
@@ -73,6 +73,8 @@ public abstract class JazzerPlugin implements Plugin<Project> {
 
             task.getClasspath().setFrom(jazzerBaseClasspath);
             task.getOutputDirectory().convention(project.getLayout().getBuildDirectory().dir("cluster-fuzz"));
+            task.getJazzerDriver().convention("jazzer_driver");
+            task.getJazzerAgent().convention("jazzer_agent_deploy.jar");
             task.getSourcePath().setFrom(jazzerBaseClasspath.getIncoming().artifactView(v -> {
                 v.withVariantReselection();
                 v.attributes(attributes -> {

--- a/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTask.java
+++ b/jazzer-plugin/src/main/java/io/micronaut/fuzzing/jazzer/PrepareClusterFuzzTask.java
@@ -80,6 +80,12 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
     @Optional
     public abstract Property<String> getSetupScript();
 
+    @Input
+    public abstract Property<String> getJazzerDriver();
+
+    @Input
+    public abstract Property<String> getJazzerAgent();
+
     /**
      * Introspector-specific settings. Note that these don't affect the actual fuzzing, only the
      * introspector report.
@@ -145,7 +151,7 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
                 if (jni) {
                     line.add("JAZZER_NATIVE_SANITIZERS_DIR=native-sanitizers");
                 }
-                line.add("$this_dir/jazzer_driver");
+                line.add("$this_dir/" + getJazzerDriver().get());
                 if (jni) {
                     switch (getJni().getSanitizer().getOrElse("")) {
                         case "address" -> line.add("--asan");
@@ -155,7 +161,7 @@ public abstract class PrepareClusterFuzzTask extends BaseJazzerTask {
                         }
                     }
                 }
-                line.add("--agent_path=$this_dir/jazzer_agent_deploy.jar");
+                line.add("--agent_path=$this_dir/" + getJazzerAgent().get());
                 collectArgs(line, target);
                 line.add("--cp=" + String.join(":", cp));
                 String fileName = targetNames.get(target.targetClass());

--- a/oss-fuzz/build.sh
+++ b/oss-fuzz/build.sh
@@ -3,11 +3,20 @@
 set -e
 
 export JAVA_HOME="$OUT/jdk"
+JAZZER_VERSION=$(sed -n 's/^managed-jazzer = "\(.*\)"/\1/p' micronaut-fuzzing/gradle/libs.versions.toml)
 
 curl -L -O https://corretto.aws/downloads/latest/amazon-corretto-25-x64-linux-jdk.tar.gz
 mkdir -p $JAVA_HOME
 tar -xz --strip-components=1 -f amazon-corretto-25-x64-linux-jdk.tar.gz --directory $JAVA_HOME
 rm -rf $JAVA_HOME/jmods $JAVA_HOME/lib/src.zip
+
+curl -fL -O "https://github.com/CodeIntelligenceTesting/jazzer/releases/download/v${JAZZER_VERSION}/jazzer-linux-x86-64.tar.gz"
+rm -rf jazzer
+mkdir jazzer
+tar -xz -f jazzer-linux-x86-64.tar.gz --directory jazzer
+cp jazzer/jazzer "$OUT/micronaut_jazzer_driver"
+cp jazzer/jazzer_standalone.jar "$OUT/micronaut_jazzer_agent_deploy.jar"
+chmod +x "$OUT/micronaut_jazzer_driver"
 
 export PATH="$JAVA_HOME/bin:$PATH"
 


### PR DESCRIPTION
## Summary
- add configurable Jazzer driver and agent paths to the ClusterFuzz wrapper task
- install the project-pinned Jazzer release under Micronaut-specific artifact names in OSS-Fuzz builds
- keep OSS-Fuzz-provided Jazzer files untouched while preserving Micronaut instrumentation coverage

## Verification
- `bash -n oss-fuzz/build.sh`
- `./gradlew --max-workers 2 micronaut-jazzer-plugin:compileJava micronaut-fuzzing-tests:prepareClusterFuzz --console=plain`
- generated wrappers use `micronaut_jazzer_driver` and `micronaut_jazzer_agent_deploy.jar`

Resolves #220