### PR TITLE
Fix HTTP client upgrade fuzz regression

### DIFF
--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -55,6 +55,22 @@ val lz4FrameDecoderRegression by tasks.registering(JazzerRegressionTask::class) 
     """.trimIndent())
 }
 
+val httpClientUpgradeHandlerRegression by tasks.registering(JazzerRegressionTask::class) {
+    description = "Runs the HTTP client upgrade handler OSS-Fuzz regression input."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+    targets.set(setOf("io.netty.handler.codec.http.HttpClientUpgradeHandlerFuzzer"))
+    jvmArgs.set(listOf(
+        "-Dio.netty.customResourceLeakDetector=io.netty.util.LeakPresenceDetector",
+        "-Dio.netty.leakDetection.targetRecords=0",
+        "--enable-preview"
+    ))
+    base64RegressionInputs.put("oss-fuzz-5406620929818624", """
+        SFRUUC8wLjIJMTAxIAAABA7+/7ktMQBEDQoNCgAAAAQAAAAAAAAAAUxBQkVMAAAAAAABRf8A2goA
+        AAQAAAAAADAuMhwAAAAAAAAxCQEAAAAAZaXEMjE0AAAAAUX/ANoKAAAEAADMzMzMzMw5NjcyNkk=
+    """.trimIndent())
+}
+
 val sanitizerTest by tasks.registering(Test::class) {
     description = "Runs sanitizer bytecode transformation tests in an isolated JVM."
     group = LifecycleBasePlugin.VERIFICATION_GROUP
@@ -76,6 +92,7 @@ val sanitizerTest by tasks.registering(Test::class) {
 tasks.named("check") {
     dependsOn(sanitizerTest)
     dependsOn(lz4FrameDecoderRegression)
+    dependsOn(httpClientUpgradeHandlerRegression)
 }
 
 group = "io.micronaut.fuzzing"

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandlerFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandlerFuzzer.java
@@ -26,6 +26,7 @@ import io.netty.handler.HandlerFuzzerBase;
 import io.netty.handler.codec.http2.Http2ClientUpgradeCodec;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
+import io.netty.handler.codec.http2.Http2FrameStreamException;
 
 
 /**
@@ -44,7 +45,7 @@ public class HttpClientUpgradeHandlerFuzzer extends HandlerFuzzerBase {
             .addLast(new ChannelInboundHandlerAdapter() {
                 @Override
                 public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-                    if (cause instanceof Http2Exception || cause instanceof IllegalStateException) {
+                    if (isExpected(cause)) {
                         return;
                     }
                     super.exceptionCaught(ctx, cause);
@@ -53,6 +54,18 @@ public class HttpClientUpgradeHandlerFuzzer extends HandlerFuzzerBase {
 
         channel.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/", channel.alloc().buffer()));
         return channel;
+    }
+
+    @Override
+    protected void onException(Exception e) {
+        if (isExpected(e)) {
+            return;
+        }
+        super.onException(e);
+    }
+
+    private static boolean isExpected(Throwable cause) {
+        return cause instanceof Http2Exception || cause instanceof Http2FrameStreamException || cause instanceof IllegalStateException;
     }
 
     public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) throws Exception {


### PR DESCRIPTION
## Summary
- treat Netty HTTP/2 frame stream exceptions as expected protocol failures in the client upgrade fuzzer
- add OSS-Fuzz testcase 5406620929818624 as a Jazzer regression input
- wire the new regression into the fuzzing-tests check task

## Verification
- ./gradlew :micronaut-fuzzing-tests:httpClientUpgradeHandlerRegression --stacktrace
- ./gradlew :micronaut-fuzzing-tests:check --stacktrace
- ./gradlew :micronaut-fuzzing-tests:spotlessApply --stacktrace