### PR TITLE
Fix JSON object decoder fuzz regression

### DIFF
--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -84,6 +84,19 @@ val brotliDecoderRegression by tasks.registering(JazzerRegressionTask::class) {
     base64RegressionInputs.put("oss-fuzz-5310533434933248", "A37///8A")
 }
 
+val jsonObjectDecoderRegression by tasks.registering(JazzerRegressionTask::class) {
+    description = "Runs the JSON object decoder OSS-Fuzz regression input."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+    targets.set(setOf("io.netty.handler.codec.json.JsonObjectDecoderFuzzer"))
+    jvmArgs.set(listOf(
+        "-Dio.netty.customResourceLeakDetector=io.netty.util.LeakPresenceDetector",
+        "-Dio.netty.leakDetection.targetRecords=0",
+        "--enable-preview"
+    ))
+    base64RegressionInputs.put("oss-fuzz-5825897350103040", "fgADpg==")
+}
+
 val sanitizerTest by tasks.registering(Test::class) {
     description = "Runs sanitizer bytecode transformation tests in an isolated JVM."
     group = LifecycleBasePlugin.VERIFICATION_GROUP
@@ -107,6 +120,7 @@ tasks.named("check") {
     dependsOn(lz4FrameDecoderRegression)
     dependsOn(httpClientUpgradeHandlerRegression)
     dependsOn(brotliDecoderRegression)
+    dependsOn(jsonObjectDecoderRegression)
 }
 
 group = "io.micronaut.fuzzing"

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/json/JsonObjectDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/json/JsonObjectDecoderFuzzer.java
@@ -21,6 +21,8 @@ import io.micronaut.fuzzing.FuzzTarget;
 import io.micronaut.fuzzing.HttpDict;
 import io.micronaut.fuzzing.runner.LocalJazzerRunner;
 import io.netty.handler.HandlerFuzzerBase;
+import io.netty.handler.codec.CorruptedFrameException;
+import io.netty.handler.codec.TooLongFrameException;
 
 
 /**
@@ -43,6 +45,14 @@ public class JsonObjectDecoderFuzzer extends HandlerFuzzerBase {
         channel.pipeline()
             .addLast(new JsonObjectDecoder(maxObjectLength, streamArrayElements));
         return channel;
+    }
+
+    @Override
+    protected void onException(Exception e) {
+        if (e instanceof CorruptedFrameException || e instanceof TooLongFrameException) {
+            return;
+        }
+        super.onException(e);
     }
 
     public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) {


### PR DESCRIPTION
## Summary
- Treat JsonObjectDecoder CorruptedFrameException and TooLongFrameException as expected fuzz-input rejections
- Add OSS-Fuzz regression coverage for testcase 5825897350103040
- Wire the regression task into check

## Verification
- JAVA_HOME=/usr/lib/jvm/java-25 ./gradlew :micronaut-fuzzing-tests:jsonObjectDecoderRegression --quiet
- JAVA_HOME=/usr/lib/jvm/java-25 ./gradlew :micronaut-fuzzing-tests:compileJava :micronaut-fuzzing-tests:check --quiet