### PR TITLE
Add HTTP content compressor fuzzer

### DIFF
--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpContentCompressorFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpContentCompressorFuzzer.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.netty.handler.codec.http;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import io.micronaut.fuzzing.FlagAppender;
+import io.micronaut.fuzzing.FuzzTarget;
+import io.micronaut.fuzzing.HttpDict;
+import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.LeakPresenceDetector;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.FastThreadLocalThread;
+
+/**
+ * Fuzzing support type.
+ */
+@FuzzTarget
+@HttpDict
+public final class HttpContentCompressorFuzzer {
+    private static final int MAX_ACCEPT_ENCODING_LENGTH = 128;
+    private static final int MAX_BODY_LENGTH = 4096;
+    private static final int MAX_CHUNKS = 16;
+
+    private static final String[] ACCEPT_ENCODINGS = {
+        "gzip",
+        "deflate",
+        "br",
+        "zstd",
+        "snappy",
+        "gzip, deflate, br",
+        "br;q=1.0, gzip;q=0.8, *;q=0.1",
+        "zstd;q=0.9, snappy;q=0.5, identity;q=0",
+        "*",
+        "identity"
+    };
+
+    private static final String[] CONTENT_ENCODINGS = {
+        "gzip",
+        "deflate",
+        "br",
+        "zstd",
+        "snappy",
+        "identity"
+    };
+
+    private static final HttpMethod[] METHODS = {
+        HttpMethod.GET,
+        HttpMethod.POST,
+        HttpMethod.HEAD,
+        HttpMethod.CONNECT
+    };
+
+    private static final int[] RESPONSE_CODES = {
+        100,
+        101,
+        200,
+        201,
+        204,
+        206,
+        304,
+        400,
+        500
+    };
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) {
+        byte[] body = fuzzedDataProvider.consumeBytes(fuzzedDataProvider.consumeInt(0, MAX_BODY_LENGTH));
+        FastThreadLocalThread.runWithFastThreadLocal(() -> test(fuzzedDataProvider, body));
+    }
+
+    private static void test(FuzzedDataProvider data, byte[] body) {
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpContentCompressor());
+        try {
+            writeRequest(data, channel);
+            drain(channel);
+
+            writeResponse(data, channel, body.length);
+            writeContent(data, channel, body);
+            channel.finish();
+        } finally {
+            drain(channel);
+            channel.releaseInbound();
+            channel.releaseOutbound();
+            LeakPresenceDetector.check();
+            FlagAppender.checkTriggered();
+        }
+    }
+
+    private static void writeRequest(FuzzedDataProvider data, EmbeddedChannel channel) {
+        HttpMethod method = data.pickValue(METHODS);
+        DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, method, "/");
+        request.headers().add(HttpHeaderNames.ACCEPT_ENCODING, acceptEncoding(data));
+        if (data.consumeBoolean()) {
+            request.headers().add(HttpHeaderNames.ACCEPT_ENCODING, acceptEncoding(data));
+        }
+        channel.writeInbound(request);
+    }
+
+    private static String acceptEncoding(FuzzedDataProvider data) {
+        return switch (data.consumeInt(0, 4)) {
+            case 0 -> data.pickValue(ACCEPT_ENCODINGS);
+            case 1 -> data.pickValue(ACCEPT_ENCODINGS) + ", " + data.pickValue(ACCEPT_ENCODINGS);
+            case 2 -> data.pickValue(CONTENT_ENCODINGS) + ";q=" + data.consumeInt(0, 100) / 100.0;
+            case 3 -> "*;q=" + data.consumeInt(0, 100) / 100.0;
+            default -> sanitizeHeaderValue(data.consumeString(MAX_ACCEPT_ENCODING_LENGTH));
+        };
+    }
+
+    private static String sanitizeHeaderValue(String value) {
+        StringBuilder builder = new StringBuilder(value.length());
+        for (int i = 0; i < value.length() && builder.length() < MAX_ACCEPT_ENCODING_LENGTH; i++) {
+            char c = value.charAt(i);
+            if (c >= 0x20 && c <= 0x7e) {
+                builder.append(c);
+            }
+        }
+        String headerValue = builder.toString().trim();
+        if (headerValue.isEmpty()) {
+            return "gzip";
+        }
+        return headerValue;
+    }
+
+    private static void writeResponse(FuzzedDataProvider data, EmbeddedChannel channel, int bodyLength) {
+        HttpResponseStatus status = HttpResponseStatus.valueOf(data.pickValue(RESPONSE_CODES));
+        DefaultHttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
+        if (data.consumeBoolean()) {
+            response.headers().set(HttpHeaderNames.CONTENT_LENGTH, bodyLength);
+        }
+        if (data.consumeBoolean()) {
+            response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/octet-stream");
+        }
+        if (data.consumeBoolean()) {
+            response.headers().set(HttpHeaderNames.CONTENT_ENCODING, data.pickValue(CONTENT_ENCODINGS));
+        }
+        channel.writeOutbound(response);
+    }
+
+    private static void writeContent(FuzzedDataProvider data, EmbeddedChannel channel, byte[] body) {
+        int chunkCount = body.length == 0 ? 0 : data.consumeInt(0, Math.min(MAX_CHUNKS, body.length));
+        int offset = 0;
+        for (int i = 0; i < chunkCount && offset < body.length; i++) {
+            int length = data.consumeInt(0, body.length - offset);
+            if (length == 0) {
+                continue;
+            }
+            writeOutbound(channel, new DefaultHttpContent(buffer(channel, body, offset, length)));
+            offset += length;
+        }
+        writeOutbound(channel, new DefaultLastHttpContent(buffer(channel, body, offset, body.length - offset)));
+    }
+
+    private static ByteBuf buffer(EmbeddedChannel channel, byte[] body, int offset, int length) {
+        ByteBuf buffer = channel.alloc().buffer(length);
+        buffer.writeBytes(body, offset, length);
+        return buffer;
+    }
+
+    private static void writeOutbound(EmbeddedChannel channel, HttpObject message) {
+        boolean written = false;
+        try {
+            channel.writeOutbound(message);
+            written = true;
+        } finally {
+            if (!written) {
+                ReferenceCountUtil.release(message);
+            }
+        }
+    }
+
+    private static void drain(EmbeddedChannel channel) {
+        Object message;
+        while ((message = channel.readInbound()) != null) {
+            ReferenceCountUtil.release(message);
+        }
+        while ((message = channel.readOutbound()) != null) {
+            ReferenceCountUtil.release(message);
+        }
+    }
+
+    public static void main(String[] args) {
+        LocalJazzerRunner.create(HttpContentCompressorFuzzer.class).fuzz();
+    }
+}

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpContentCompressorFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpContentCompressorFuzzer.java
@@ -16,10 +16,12 @@
 package io.netty.handler.codec.http;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import io.micronaut.fuzzing.Dict;
 import io.micronaut.fuzzing.FlagAppender;
 import io.micronaut.fuzzing.FuzzTarget;
 import io.micronaut.fuzzing.HttpDict;
 import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import io.micronaut.fuzzing.util.ByteSplitter;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.LeakPresenceDetector;
@@ -31,32 +33,25 @@ import io.netty.util.concurrent.FastThreadLocalThread;
  */
 @FuzzTarget
 @HttpDict
+@Dict({
+    "gzip",
+    "deflate",
+    "br",
+    "zstd",
+    "snappy",
+    "identity",
+    "*",
+    ";q=",
+    ", ",
+    "SEP",
+    "gzip, deflate, br",
+    "br;q=1.0, gzip;q=0.8, *;q=0.1",
+    "zstd;q=0.9, snappy;q=0.5, identity;q=0"
+})
 public final class HttpContentCompressorFuzzer {
+    private static final ByteSplitter SPLITTER = ByteSplitter.create("SEP");
     private static final int MAX_ACCEPT_ENCODING_LENGTH = 128;
     private static final int MAX_BODY_LENGTH = 4096;
-    private static final int MAX_CHUNKS = 16;
-
-    private static final String[] ACCEPT_ENCODINGS = {
-        "gzip",
-        "deflate",
-        "br",
-        "zstd",
-        "snappy",
-        "gzip, deflate, br",
-        "br;q=1.0, gzip;q=0.8, *;q=0.1",
-        "zstd;q=0.9, snappy;q=0.5, identity;q=0",
-        "*",
-        "identity"
-    };
-
-    private static final String[] CONTENT_ENCODINGS = {
-        "gzip",
-        "deflate",
-        "br",
-        "zstd",
-        "snappy",
-        "identity"
-    };
 
     private static final HttpMethod[] METHODS = {
         HttpMethod.GET,
@@ -89,7 +84,7 @@ public final class HttpContentCompressorFuzzer {
             drain(channel);
 
             writeResponse(data, channel, body.length);
-            writeContent(data, channel, body);
+            writeContent(channel, body);
             channel.finish();
         } finally {
             drain(channel);
@@ -111,13 +106,7 @@ public final class HttpContentCompressorFuzzer {
     }
 
     private static String acceptEncoding(FuzzedDataProvider data) {
-        return switch (data.consumeInt(0, 4)) {
-            case 0 -> data.pickValue(ACCEPT_ENCODINGS);
-            case 1 -> data.pickValue(ACCEPT_ENCODINGS) + ", " + data.pickValue(ACCEPT_ENCODINGS);
-            case 2 -> data.pickValue(CONTENT_ENCODINGS) + ";q=" + data.consumeInt(0, 100) / 100.0;
-            case 3 -> "*;q=" + data.consumeInt(0, 100) / 100.0;
-            default -> sanitizeHeaderValue(data.consumeString(MAX_ACCEPT_ENCODING_LENGTH));
-        };
+        return sanitizeHeaderValue(data.consumeString(MAX_ACCEPT_ENCODING_LENGTH));
     }
 
     private static String sanitizeHeaderValue(String value) {
@@ -145,23 +134,22 @@ public final class HttpContentCompressorFuzzer {
             response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/octet-stream");
         }
         if (data.consumeBoolean()) {
-            response.headers().set(HttpHeaderNames.CONTENT_ENCODING, data.pickValue(CONTENT_ENCODINGS));
+            response.headers().set(HttpHeaderNames.CONTENT_ENCODING, sanitizeHeaderValue(data.consumeString(MAX_ACCEPT_ENCODING_LENGTH)));
         }
         channel.writeOutbound(response);
     }
 
-    private static void writeContent(FuzzedDataProvider data, EmbeddedChannel channel, byte[] body) {
-        int chunkCount = body.length == 0 ? 0 : data.consumeInt(0, Math.min(MAX_CHUNKS, body.length));
-        int offset = 0;
-        for (int i = 0; i < chunkCount && offset < body.length; i++) {
-            int length = data.consumeInt(0, body.length - offset);
-            if (length == 0) {
-                continue;
+    private static void writeContent(EmbeddedChannel channel, byte[] body) {
+        ByteSplitter.ChunkIterator chunks = SPLITTER.splitIterator(body);
+        while (chunks.hasNext()) {
+            chunks.proceed();
+            ByteBuf content = buffer(channel, body, chunks.start(), chunks.length());
+            if (chunks.hasNext()) {
+                writeOutbound(channel, new DefaultHttpContent(content));
+            } else {
+                writeOutbound(channel, new DefaultLastHttpContent(content));
             }
-            writeOutbound(channel, new DefaultHttpContent(buffer(channel, body, offset, length)));
-            offset += length;
         }
-        writeOutbound(channel, new DefaultLastHttpContent(buffer(channel, body, offset, body.length - offset)));
     }
 
     private static ByteBuf buffer(EmbeddedChannel channel, byte[] body, int offset, int length) {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpContentCompressorFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/HttpContentCompressorFuzzer.java
@@ -28,6 +28,13 @@ import io.netty.util.LeakPresenceDetector;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.FastThreadLocalThread;
 
+final class HttpContentCompressorFuzzerConstants {
+    static final String SEPARATOR = "SEP";
+
+    private HttpContentCompressorFuzzerConstants() {
+    }
+}
+
 /**
  * Fuzzing support type.
  */
@@ -43,13 +50,13 @@ import io.netty.util.concurrent.FastThreadLocalThread;
     "*",
     ";q=",
     ", ",
-    "SEP",
+    HttpContentCompressorFuzzerConstants.SEPARATOR,
     "gzip, deflate, br",
     "br;q=1.0, gzip;q=0.8, *;q=0.1",
     "zstd;q=0.9, snappy;q=0.5, identity;q=0"
 })
 public final class HttpContentCompressorFuzzer {
-    private static final ByteSplitter SPLITTER = ByteSplitter.create("SEP");
+    private static final ByteSplitter SPLITTER = ByteSplitter.create(HttpContentCompressorFuzzerConstants.SEPARATOR);
     private static final int MAX_ACCEPT_ENCODING_LENGTH = 128;
     private static final int MAX_BODY_LENGTH = 4096;
 
@@ -81,15 +88,12 @@ public final class HttpContentCompressorFuzzer {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpContentCompressor());
         try {
             writeRequest(data, channel);
-            drain(channel);
+            channel.releaseInbound();
 
             writeResponse(data, channel, body.length);
             writeContent(channel, body);
-            channel.finish();
         } finally {
-            drain(channel);
-            channel.releaseInbound();
-            channel.releaseOutbound();
+            channel.finishAndReleaseAll();
             LeakPresenceDetector.check();
             FlagAppender.checkTriggered();
         }
@@ -167,16 +171,6 @@ public final class HttpContentCompressorFuzzer {
             if (!written) {
                 ReferenceCountUtil.release(message);
             }
-        }
-    }
-
-    private static void drain(EmbeddedChannel channel) {
-        Object message;
-        while ((message = channel.readInbound()) != null) {
-            ReferenceCountUtil.release(message);
-        }
-        while ((message = channel.readOutbound()) != null) {
-            ReferenceCountUtil.release(message);
         }
     }
 


### PR DESCRIPTION
## Summary
- add a Netty `HttpContentCompressor` fuzz target in the mirrored `io.netty.handler.codec.http` package
- exercise varied `Accept-Encoding` headers, response metadata, payload bytes, and outbound content chunking
- rely on `@FuzzTarget`/`@HttpDict` metadata for ClusterFuzz target discovery

## Verification
- `./gradlew --no-daemon micronaut-fuzzing-tests:compileJava -q`
- `./gradlew --no-daemon micronaut-fuzzing-tests:prepareClusterFuzz -q`
- `./gradlew --no-daemon spotlessApply check -q -x japiCmp`
- bounded local Jazzer run for `io.netty.handler.codec.http.HttpContentCompressorFuzzer` via a temporary init script: 12049 runs, no crash

Resolves #236