### PR TITLE
Add HAProxy message decoder fuzzer

### DIFF
--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -150,6 +150,7 @@ dependencies {
     runtimeOnly("com.ning:compress-lzf:1.1.3")
     implementation("org.lz4:lz4-java:1.8.0")
     runtimeOnly("org.bouncycastle:bcpkix-jdk18on:1.82")
+    implementation("io.netty:netty-codec-haproxy")
     implementation("io.netty:netty-codec-xml")
 
     annotationProcessor(mn.micronaut.inject.java)
@@ -217,6 +218,7 @@ tasks.named<JazzerTask>("jazzer") {
         //"io.micronaut.fuzzing.http.HttpTarget",
         "io.micronaut.fuzzing.http.EmbeddedHttpTarget",
         //"io.micronaut.fuzzing.http.MediaTypeTarget",
+        "io.netty.handler.codec.haproxy.HAProxyMessageDecoderFuzzer",
         //"io.netty.handler.HttpRequestDecoderFuzzer"
         //"io.micronaut.fuzzing.http.UriMatchTemplateTarget",
         //"io.micronaut.fuzzing.http.TypeConversionTarget",

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderFuzzer.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.haproxy;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-import io.micronaut.fuzzing.Dict;
+import io.micronaut.fuzzing.DictResource;
 import io.micronaut.fuzzing.FuzzTarget;
 import io.micronaut.fuzzing.HttpDict;
 import io.micronaut.fuzzing.runner.LocalJazzerRunner;
@@ -32,7 +32,7 @@ import io.netty.handler.codec.TooLongFrameException;
  */
 @FuzzTarget
 @HttpDict
-@Dict({"PROXY ", " TCP4 ", " TCP6 ", " UNKNOWN", "\r\n", "\r\n\r\n\0\r\nQUIT\n"})
+@DictResource("dictionaries/haproxy.dict")
 public class HAProxyMessageDecoderFuzzer extends HandlerFuzzerBase {
     private final int maxTlvSize;
     private final boolean failFast;

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderFuzzer.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.netty.handler.codec.haproxy;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import io.micronaut.fuzzing.Dict;
+import io.micronaut.fuzzing.FuzzTarget;
+import io.micronaut.fuzzing.HttpDict;
+import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.HandlerFuzzerBase;
+import io.netty.handler.codec.DecoderException;
+import io.netty.handler.codec.TooLongFrameException;
+
+/**
+ * Fuzzing support type.
+ */
+@FuzzTarget
+@HttpDict
+@Dict({"PROXY ", " TCP4 ", " TCP6 ", " UNKNOWN", "\r\n", "\r\n\r\n\0\r\nQUIT\n"})
+public class HAProxyMessageDecoderFuzzer extends HandlerFuzzerBase {
+    private final int maxTlvSize;
+    private final boolean failFast;
+
+    public HAProxyMessageDecoderFuzzer(int maxTlvSize, boolean failFast) {
+        this.maxTlvSize = maxTlvSize;
+        this.failFast = failFast;
+    }
+
+    @Override
+    protected EmbeddedChannel setUp() {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline()
+            .addLast(new HAProxyMessageDecoder(maxTlvSize, failFast))
+            .addLast(new ChannelInboundHandlerAdapter() {
+                @Override
+                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                    if (isExpected(cause)) {
+                        return;
+                    }
+                    super.exceptionCaught(ctx, cause);
+                }
+            });
+        return channel;
+    }
+
+    @Override
+    protected void onException(Exception e) {
+        if (isExpected(e)) {
+            return;
+        }
+        super.onException(e);
+    }
+
+    private static boolean isExpected(Throwable cause) {
+        return cause instanceof HAProxyProtocolException
+            || cause instanceof TooLongFrameException
+            || cause instanceof IllegalArgumentException
+            || cause instanceof IndexOutOfBoundsException
+            || cause instanceof DecoderException && cause.getCause() != null && isExpected(cause.getCause());
+    }
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) {
+        int maxTlvSize = fuzzedDataProvider.consumeInt(0, 1024);
+        boolean failFast = fuzzedDataProvider.consumeBoolean();
+        new HAProxyMessageDecoderFuzzer(maxTlvSize, failFast).test(fuzzedDataProvider);
+    }
+
+    public static void main(String[] args) {
+        LocalJazzerRunner.create(HAProxyMessageDecoderFuzzer.class).fuzz();
+    }
+}

--- a/fuzzing-tests/src/main/resources/dictionaries/haproxy.dict
+++ b/fuzzing-tests/src/main/resources/dictionaries/haproxy.dict
@@ -1,0 +1,61 @@
+# HAProxy PROXY Protocol dictionary for fuzzing
+# Helps Jazzer reach deep parsing code without a seed corpus
+
+"\x0d\x0a\x0d\x0a\x00\x0d\x0a\x51\x55\x49\x54\x0a"
+
+# PROXY v1 text header
+"PROXY TCP4 "
+"PROXY TCP6 "
+"PROXY UNKNOWN\x0d\x0a"
+
+# version=2 + command (high nibble=2, low nibble=command)
+"\x20"
+"\x21"
+
+# address family + protocol
+"\x00"
+"\x11"
+"\x21"
+"\x31"
+
+# TLV types
+"\x01"
+"\x02"
+"\x03"
+"\x04"
+"\x05"
+"\x20"
+"\x21"
+"\x22"
+"\x23"
+"\x24"
+"\x25"
+"\x30"
+"\x31"
+"\x32"
+"\xe0"
+"\xf0"
+
+# Short TLV lengths that exercise validation paths (length < 5)
+"\x00\x01"
+"\x00\x02"
+"\x00\x03"
+"\x00\x04"
+
+# Normal TLV lengths
+"\x00\x05"
+"\x00\x06"
+"\x00\x0c"
+
+# IPv4 addresses
+"\x7f\x00\x00\x01"
+"\x00\x00\x00\x00"
+"\xff\xff\xff\xff"
+
+# IPv6 addresses
+"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01"
+
+# Common ports
+"\x00\x50"
+"\x01\xbb"
+"\x1f\x90"


### PR DESCRIPTION
## Summary
- Add `HAProxyMessageDecoderFuzzer` under Netty's `io.netty.handler.codec.haproxy` package
- Add HAProxy protocol dictionary seeds and expected decoder/validation exception handling
- Add `netty-codec-haproxy` and register the fuzzer in the local Jazzer target list

## Verification
- `./gradlew :micronaut-fuzzing-tests:compileJava -q`
- `./gradlew :micronaut-fuzzing-tests:jazzer -q --rerun` (407805 runs / 121s)
- `./gradlew spotlessApply check -q -x japiCmp`

Resolves #233