### PR TITLE
Add HPACK decoder fuzzer

### DIFF
--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -217,6 +217,7 @@ tasks.named<JazzerTask>("jazzer") {
         //"io.micronaut.fuzzing.http.HttpTarget",
         "io.micronaut.fuzzing.http.EmbeddedHttpTarget",
         //"io.micronaut.fuzzing.http.MediaTypeTarget",
+        "io.netty.handler.codec.http2.HpackDecoderFuzzer",
         //"io.netty.handler.HttpRequestDecoderFuzzer"
         //"io.micronaut.fuzzing.http.UriMatchTemplateTarget",
         //"io.micronaut.fuzzing.http.TypeConversionTarget",

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http2/HpackDecoderFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http2/HpackDecoderFuzzer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import io.micronaut.fuzzing.Dict;
+import io.micronaut.fuzzing.DictResource;
+import io.micronaut.fuzzing.FuzzTarget;
+import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import io.micronaut.fuzzing.sanitizer.SanitizerTransformer;
+import io.micronaut.fuzzing.util.ByteSplitter;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * Fuzz target for Netty's HPACK decoder.
+ */
+@FuzzTarget
+@Dict("SEP")
+@DictResource("dictionaries/hpack.dict")
+public class HpackDecoderFuzzer {
+    private static final long MAX_HEADER_LIST_SIZE = 8192;
+    private static final ByteSplitter SPLITTER = ByteSplitter.create("SEP");
+
+    static {
+        SanitizerTransformer.installLocally();
+    }
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) throws Exception {
+        HpackDecoder decoder = new HpackDecoder(MAX_HEADER_LIST_SIZE);
+        Http2Headers headers = new DefaultHttp2Headers();
+        byte[] allBytes = fuzzedDataProvider.consumeRemainingAsBytes();
+        ByteSplitter.ChunkIterator itr = SPLITTER.splitIterator(allBytes);
+
+        while (itr.hasNext()) {
+            itr.proceed();
+            ByteBuf buffer = Unpooled.wrappedBuffer(allBytes, itr.start(), itr.length());
+            try {
+                decoder.decode(1, buffer, headers, true);
+                headers.clear();
+            } catch (Http2Exception | IllegalArgumentException e) {
+                return;
+            } finally {
+                buffer.release();
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        LocalJazzerRunner.create(HpackDecoderFuzzer.class).fuzz();
+    }
+}

--- a/fuzzing-tests/src/main/resources/dictionaries/hpack.dict
+++ b/fuzzing-tests/src/main/resources/dictionaries/hpack.dict
@@ -1,0 +1,77 @@
+# HPACK dictionary for fuzzing.
+# Helps Jazzer generate valid HPACK-encoded header blocks.
+
+# Split marker for stateful header block decoding.
+"SEP"
+
+# Indexed header fields from the static table.
+"\x82"
+"\x83"
+"\x84"
+"\x85"
+"\x86"
+"\x87"
+"\x88"
+
+# Literal header forms.
+"\x40"
+"\x00"
+"\x10"
+
+# Dynamic table size updates.
+"\x20"
+"\x3f"
+"\x3f\xe1\x1f"
+"\x3f\xe0\xff\x03"
+"\x3f\xff\xff\x7f"
+"\x3f\xff\xff\xff\x0f"
+
+# HPACK integer encodings.
+"\x7f\x00"
+"\x7f\x01"
+"\x7f\x80\x01"
+"\x7f\xff\x7f"
+"\x7f\x80\x80\x80\x80\x01"
+"\x7f\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01"
+
+# Huffman string prefixes and edge cases.
+"\x80"
+"\x81"
+"\xff"
+"\xff\xff\xff\xff"
+"\xff\x80\xff\x03"
+
+# Static table index boundaries.
+"\x7f\x00"
+"\xfe"
+"\xff\x00"
+"\xff\xff\x7f"
+"\xff\xff\xff\xff\x07"
+
+# String length boundaries.
+"\x00"
+"\x7f"
+"\x7f\x01"
+"\x7f\x80\xff\x03"
+"\x7f\xff\xff\x7f"
+
+# Common header names.
+":method"
+":path"
+":scheme"
+":authority"
+":status"
+"content-type"
+"content-length"
+
+# Common header values.
+"GET"
+"POST"
+"/"
+"https"
+"200"
+"application/json"
+
+# Stateful table sequences.
+"\x20\x82"
+"\x20\x3f\xe1\x1f\x20\x3f\xe1\x1f"


### PR DESCRIPTION
## Summary
- add a standalone `HpackDecoderFuzzer` in Netty's `io.netty.handler.codec.http2` package
- add an HPACK dictionary with static table, literal, table-size, Huffman, and `SEP` entries for stateful block splitting
- include the HPACK target in the local `jazzer` target list

## Notes
- SNI was excluded because `SniHandlerFuzzer` is already merged in #251.
- HAProxy was excluded because `HAProxyMessageDecoderFuzzer` is already covered by #256.
- This extracts only the HPACK portion from #257.

## Verification
- `./gradlew --no-daemon :micronaut-fuzzing-tests:compileJava -q`
- `./gradlew --no-daemon :micronaut-fuzzing-tests:prepareClusterFuzz -q`
- `./gradlew --no-daemon spotlessApply check -q -x japiCmp`
- `./gradlew --no-daemon :micronaut-fuzzing-tests:jazzer -q --rerun` (400,449 runs, no crash)
- HPACK-only Jazzer run via temporary init script (669,973 runs / 21s, no crash)