### PR TITLE
Scope vulnerability audit to Jazzer plugin

### DIFF
--- a/.github/scripts/vulnerability-audit.sh
+++ b/.github/scripts/vulnerability-audit.sh
@@ -8,14 +8,14 @@ readonly UPSTREAM_GROUP_PREFIXES="${UPSTREAM_GROUP_PREFIXES:-io.micronaut}"
 readonly VULNERABILITY_AUDIT_ENFORCEMENT="${VULNERABILITY_AUDIT_ENFORCEMENT:-fail}"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-cd "${ROOT_DIR}"
+AUDIT_DIR="${ROOT_DIR}/jazzer-plugin"
 
 if [[ "${VULNERABILITY_AUDIT_ENFORCEMENT}" != "fail" && "${VULNERABILITY_AUDIT_ENFORCEMENT}" != "advisory" ]]; then
     echo "VULNERABILITY_AUDIT_ENFORCEMENT must be 'fail' or 'advisory'" >&2
     exit 1
 fi
 
-if [[ ! -x ./gradlew ]]; then
+if [[ ! -x "${ROOT_DIR}/gradlew" ]]; then
     echo "Gradle wrapper not found or not executable at ${ROOT_DIR}/gradlew" >&2
     exit 1
 fi
@@ -53,18 +53,20 @@ allprojects {
 }
 GRADLE
 
-echo "Generating CycloneDX SBOM at ${SBOM_PATH}"
-./gradlew :cyclonedxBom --init-script "${init_script}" --no-parallel --info
+echo "Generating CycloneDX SBOM at ${AUDIT_DIR}/${SBOM_PATH}"
+cd "${AUDIT_DIR}"
+"${ROOT_DIR}/gradlew" :cyclonedxBom --init-script "${init_script}" --no-parallel --info
 
 if [[ ! -s "${SBOM_PATH}" ]]; then
-    echo "CycloneDX SBOM was not generated at ${SBOM_PATH}" >&2
+    echo "CycloneDX SBOM was not generated at ${AUDIT_DIR}/${SBOM_PATH}" >&2
     exit 1
 fi
 
 osv_args=(
     run
     --rm
-    -v "${ROOT_DIR}:/src:ro"
+    -v "${AUDIT_DIR}:/src:ro"
+    -v "${ROOT_DIR}:/repo:ro"
     -w /src
     "${OSV_SCANNER_IMAGE}"
     scan
@@ -80,9 +82,9 @@ osv_args=(
     warn
 )
 
-if [[ -f osv-scanner.toml ]]; then
+if [[ -f "${ROOT_DIR}/osv-scanner.toml" ]]; then
     echo "Using osv-scanner.toml for vulnerability audit exceptions"
-    osv_args+=(--config /src/osv-scanner.toml)
+    osv_args+=(--config /repo/osv-scanner.toml)
 fi
 
 osv_output="${tmp_dir}/osv-results.json"
@@ -102,8 +104,8 @@ if [[ ${osv_status} -ne 0 && ${osv_status} -ne 1 ]]; then
 fi
 
 set +e
-python3 .github/scripts/vulnerability-audit-filter.py \
-    --sbom "${SBOM_PATH}" \
+python3 "${ROOT_DIR}/.github/scripts/vulnerability-audit-filter.py" \
+    --sbom "${AUDIT_DIR}/${SBOM_PATH}" \
     --osv "${osv_output}" \
     --upstream-group-prefixes "${UPSTREAM_GROUP_PREFIXES}"
 filter_status=$?


### PR DESCRIPTION
## Summary
- run the vulnerability audit from the `jazzer-plugin` included build
- scan the generated Jazzer plugin SBOM while keeping root OSV config/filter support
- avoid auditing the root fuzzing modules where vulnerable dependencies may be intentional

## Verification
- `bash -n .github/scripts/vulnerability-audit.sh`
- `python3 -m py_compile .github/scripts/vulnerability-audit-filter.py`
- PyYAML parse of `.github/workflows/sonatype.yml` and `.github/workflows/release.yml`
- `GIT_MASTER=1 git diff --check`
- `JAVA_HOME=/usr/lib64/graalvm/graalvm-java25 ./gradlew -p jazzer-plugin check --no-daemon`
- generated CycloneDX SBOM metadata: `io.micronaut.fuzzing:micronaut-jazzer-plugin:0.2.0-SNAPSHOT`
- `.github/scripts/vulnerability-audit.sh` reaches OSV scan locally; local Podman fails before scanning with `newuidmap` permissions (environment limitation)

Resolves #260