### PR TITLE
Fix Bzip2 decoder fuzz regression

### DIFF
--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -84,6 +84,22 @@ val brotliDecoderRegression by tasks.registering(JazzerRegressionTask::class) {
     base64RegressionInputs.put("oss-fuzz-5310533434933248", "A37///8A")
 }
 
+val bzip2DecoderRegression by tasks.registering(JazzerRegressionTask::class) {
+    description = "Runs the Bzip2 decoder OSS-Fuzz regression input."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+    targets.set(setOf("io.netty.handler.codec.compression.Bzip2DecoderFuzzer"))
+    jvmArgs.set(listOf(
+        "-Dio.netty.customResourceLeakDetector=io.netty.util.LeakPresenceDetector",
+        "-Dio.netty.leakDetection.targetRecords=0",
+        "--enable-preview"
+    ))
+    base64RegressionInputs.put("oss-fuzz-5399056135028736", """
+        QlpoNTFBWSZTWUkAAAAAAAAAICAgICAgIAAAQlgtUmVxdWVzdGVkLVdpdGhJTkQgICAAXWphdmEv
+        dXRpbC9BcnJheXMgICAgICAgICAgICAgJAkgb1QgICQgJTU0
+    """.trimIndent())
+}
+
 val jsonObjectDecoderRegression by tasks.registering(JazzerRegressionTask::class) {
     description = "Runs the JSON object decoder OSS-Fuzz regression input."
     group = LifecycleBasePlugin.VERIFICATION_GROUP
@@ -120,6 +136,7 @@ tasks.named("check") {
     dependsOn(lz4FrameDecoderRegression)
     dependsOn(httpClientUpgradeHandlerRegression)
     dependsOn(brotliDecoderRegression)
+    dependsOn(bzip2DecoderRegression)
     dependsOn(jsonObjectDecoderRegression)
 }
 

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/EmbeddedChannelFuzzerBase.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/EmbeddedChannelFuzzerBase.java
@@ -43,6 +43,7 @@ public abstract class EmbeddedChannelFuzzerBase {
     protected long baseCpuTime = 500000;
     protected long inputCpuTime = 20;
     protected long outputCpuTime = 0;
+    protected long exceptionCpuTime = 0;
     protected boolean hasOutput = false;
 
     static {
@@ -110,7 +111,7 @@ public abstract class EmbeddedChannelFuzzerBase {
                     state.exceptionCaught = true;
                     if (cause instanceof Exception e) {
                         try {
-                            onException(e);
+                            handleException(state, e);
                         } catch (Exception f) {
                             ctx.fireExceptionCaught(f);
                         }
@@ -131,19 +132,22 @@ public abstract class EmbeddedChannelFuzzerBase {
             try {
                 channel.writeInbound(buffer);
             } catch (Exception e) {
-                onException(e);
+                handleException(state, e);
                 break; // cancel further input, but still release
             }
         }
         try {
             channel.finish();
         } catch (Exception e) {
-            onException(e);
+            handleException(state, e);
         }
         channel.releaseOutbound();
 
         long end = CpuTimer.currentThreadCpuTimeNanos();
         cpuTimeBudget += state.outputBytes * outputCpuTime;
+        if (state.handledException) {
+            cpuTimeBudget += exceptionCpuTime;
+        }
 
         LeakPresenceDetector.check();
         FlagAppender.checkTriggered();
@@ -155,8 +159,10 @@ public abstract class EmbeddedChannelFuzzerBase {
             sample.baseCpuTime = baseCpuTime;
             sample.inputCpuTime = inputCpuTime;
             sample.outputCpuTime = outputCpuTime;
+            sample.exceptionCpuTime = exceptionCpuTime;
             sample.inputSize = allBytes.length;
             sample.outputSize = state.outputBytes;
+            sample.handledException = state.handledException;
             sample.actualTime = actualTime;
             sample.commit();
         }
@@ -164,6 +170,11 @@ public abstract class EmbeddedChannelFuzzerBase {
         if (actualTime > CPU_TIME_FACTOR * cpuTimeBudget) {
             throw new CpuLimitException("CPU limit triggered. in=" + allBytes.length + " out=" + state.outputBytes + " actual=" + actualTime);
         }
+    }
+
+    private void handleException(AttemptState state, Exception e) {
+        onException(e);
+        state.handledException = true;
     }
 
     private static final class CpuLimitException extends RuntimeException {
@@ -175,6 +186,7 @@ public abstract class EmbeddedChannelFuzzerBase {
     private static final class AttemptState {
         long outputBytes;
         boolean exceptionCaught;
+        boolean handledException;
     }
 
     @Enabled(false)
@@ -184,8 +196,10 @@ public abstract class EmbeddedChannelFuzzerBase {
         long baseCpuTime;
         long inputCpuTime;
         long outputCpuTime;
+        long exceptionCpuTime;
         int inputSize;
         long outputSize;
+        boolean handledException;
         long actualTime;
     }
 }

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/DecompressorFuzzerBase.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/compression/DecompressorFuzzerBase.java
@@ -20,6 +20,7 @@ import io.netty.handler.HandlerFuzzerBase;
 abstract class DecompressorFuzzerBase extends HandlerFuzzerBase {
     DecompressorFuzzerBase() {
         outputCpuTime = inputCpuTime;
+        exceptionCpuTime = 400_000;
     }
 
     @Override


### PR DESCRIPTION
## Summary

- add a configurable CPU-time budget for exceptions handled by fuzz targets
- grant decompressor fuzzers a finite 400,000-unit exception allowance while retaining CPU-limit enforcement
- add OSS-Fuzz testcase 5399056135028736 as a Bzip2 decoder regression

The exception budget is additive, like the existing base/input/output budgets. It is applied only when `onException` returns successfully; unexpected exceptions still propagate without receiving the allowance.

## Verification

- `./gradlew :micronaut-fuzzing-tests:bzip2DecoderRegression`
- `./gradlew :micronaut-fuzzing-tests:check`
- `./gradlew spotlessCheck`