### PR TITLE
Fix SNI handler fuzz regression

### DIFF
--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -113,6 +113,26 @@ val jsonObjectDecoderRegression by tasks.registering(JazzerRegressionTask::class
     base64RegressionInputs.put("oss-fuzz-5825897350103040", "fgADpg==")
 }
 
+val sniHandlerRegression by tasks.registering(JazzerRegressionTask::class) {
+    description = "Runs the SNI handler OSS-Fuzz regression input."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+    targets.set(setOf("io.netty.handler.ssl.SniHandlerFuzzer"))
+    jvmArgs.set(listOf(
+        "-Dio.netty.customResourceLeakDetector=io.netty.util.LeakPresenceDetector",
+        "-Dio.netty.leakDetection.targetRecords=0",
+        "--enable-preview"
+    ))
+    base64RegressionInputs.put("oss-fuzz-6335646063722496", """
+        FgNdAScBAADNKSn///////+AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIB/gICAYXJy
+        YXmAgICAgICAgIAIgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIACOICA
+        gICAgICAgICAgID//////////////////////////////////////zD///9TRVD/////////////
+        //8BqwAAAAAlhQ4AAq92AAAAAAAAAAANGZgUUFNTiYlhU0VQYWFhYWFhaWFhYQAAAAAAAAAAAAAA
+        AAAAAAAAAABh///////////9//////////8A/////////////////////y7/////////////////
+        /////1NFUP////8eHh4eHh4eHh5FUEVQU0VQU0UAU2FQ
+    """.trimIndent())
+}
+
 val sanitizerTest by tasks.registering(Test::class) {
     description = "Runs sanitizer bytecode transformation tests in an isolated JVM."
     group = LifecycleBasePlugin.VERIFICATION_GROUP
@@ -138,6 +158,7 @@ tasks.named("check") {
     dependsOn(brotliDecoderRegression)
     dependsOn(bzip2DecoderRegression)
     dependsOn(jsonObjectDecoderRegression)
+    dependsOn(sniHandlerRegression)
 }
 
 group = "io.micronaut.fuzzing"

--- a/fuzzing-tests/src/main/java/io/netty/handler/ssl/SniHandlerFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/ssl/SniHandlerFuzzer.java
@@ -31,6 +31,7 @@ import io.netty.util.DomainNameMappingBuilder;
 
 import javax.net.ssl.SSLException;
 import java.security.cert.CertificateException;
+import java.text.ParseException;
 
 /**
  * Fuzz target for Netty's SNI handler.
@@ -88,6 +89,9 @@ public final class SniHandlerFuzzer extends HandlerFuzzerBase {
     private static boolean isExpected(Throwable cause) {
         if (cause instanceof TooLongFrameException ||
             cause instanceof SSLException) {
+            return true;
+        }
+        if (cause instanceof IllegalArgumentException && cause.getCause() instanceof ParseException) {
             return true;
         }
         if (!(cause instanceof DecoderException)) {


### PR DESCRIPTION
## Summary
- Treat malformed IDN/SNI hostnames as expected parser failures in `SniHandlerFuzzer`
- Add OSS-Fuzz testcase 6335646063722496 as a Jazzer regression input
- Wire the new SNI regression task into `check`

## Testing
- Reproduced failure before the fix with `./gradlew :micronaut-fuzzing-tests:sniHandlerRegression` (exit 77)
- `./gradlew :micronaut-fuzzing-tests:sniHandlerRegression`
- `./gradlew :micronaut-fuzzing-tests:check`