### PR TITLE
Add Netty HTTP/2 and WebSocket fuzzers

### DIFF
--- a/.github/scripts/vulnerability-audit.sh
+++ b/.github/scripts/vulnerability-audit.sh
@@ -43,9 +43,10 @@ initscript {
 allprojects {
     apply plugin: Class.forName('org.cyclonedx.gradle.CyclonedxPlugin')
 
-    tasks.withType(Class.forName('org.cyclonedx.gradle.CyclonedxDirectTask')).configureEach { task ->
+    tasks.withType(Class.forName('org.cyclonedx.gradle.CyclonedxDirectTask')).all { task ->
         task.enabled = false
         task.includeConfigs.set(['runtimeClasspath'])
+        task.includeMetadataResolution.set(false)
         plugins.withId('maven-publish') {
             task.enabled = true
         }

--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -24,13 +24,12 @@ tasks.withType<JavaCompile> {
 }
 
 tasks.withType<Test>() {
-    jvmArgs(
-        "--enable-preview",
-        "-Dio.netty.customResourceLeakDetector=io.netty.util.LeakPresenceDetector"
-    )
+    jvmArgs("--enable-preview")
 }
 
 tasks.named<Test>("test") {
+    forkEvery = 1
+    jvmArgs("-Dio.netty.customResourceLeakDetector=io.netty.util.LeakPresenceDetector")
     exclude("io/micronaut/fuzzing/sanitizer/SanitizerTransformerTest.class")
 }
 
@@ -192,9 +191,6 @@ dependencies {
     implementation("org.lz4:lz4-java:1.8.0")
     runtimeOnly("org.bouncycastle:bcpkix-jdk18on:1.84")
     implementation("io.netty:netty-codec-xml")
-    implementation("io.netty:netty-codec-haproxy") {
-        version { strictly("4.2.14.Final") }
-    }
 
     annotationProcessor(mn.micronaut.inject.java)
     annotationProcessor(projects.micronautFuzzingAnnotationProcessor)
@@ -259,11 +255,9 @@ tasks.named<JazzerTask>("jazzer") {
     targets.set(listOf(
         //"io.micronaut.fuzzing.toml.TomlTarget",
         //"io.micronaut.fuzzing.http.HttpTarget",
-       // "io.micronaut.fuzzing.http.EmbeddedHttpTarget",
+        "io.micronaut.fuzzing.http.EmbeddedHttpTarget",
         //"io.micronaut.fuzzing.http.MediaTypeTarget",
-        //"io.netty.handler.HttpRequestDecoderFuzzer",
-        //"io.netty.handler.codec.haproxy.HAProxyMessageDecoderFuzzer",
-        //"io.netty.handler.ssl.SniHandlerFuzzer",
+        //"io.netty.handler.HttpRequestDecoderFuzzer"
         //"io.micronaut.fuzzing.http.UriMatchTemplateTarget",
         //"io.micronaut.fuzzing.http.TypeConversionTarget",
         //"io.micronaut.fuzzing.http.ContentNegotiationTarget",

--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -28,9 +28,26 @@ tasks.withType<Test>() {
 }
 
 tasks.named<Test>("test") {
+    exclude("io/micronaut/fuzzing/sanitizer/SanitizerTransformerTest.class")
+    exclude("io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorFuzzerTest.class")
+    exclude("io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerFuzzerTest.class")
+    exclude("io/netty/handler/codec/http2/Http2ConnectionHandlerFuzzerTest.class")
+}
+
+val nettyFuzzerTest by tasks.registering(Test::class) {
+    description = "Runs Netty fuzzer smoke tests in isolated JVMs with leak detection."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    include("io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorFuzzerTest.class")
+    include("io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerFuzzerTest.class")
+    include("io/netty/handler/codec/http2/Http2ConnectionHandlerFuzzerTest.class")
+
+    shouldRunAfter(tasks.named("test"))
     forkEvery = 1
     jvmArgs("-Dio.netty.customResourceLeakDetector=io.netty.util.LeakPresenceDetector")
-    exclude("io/micronaut/fuzzing/sanitizer/SanitizerTransformerTest.class")
 }
 
 val lz4FrameDecoderRegression by tasks.registering(JazzerRegressionTask::class) {
@@ -155,6 +172,7 @@ val sanitizerTest by tasks.registering(Test::class) {
 
 tasks.named("check") {
     dependsOn(sanitizerTest)
+    dependsOn(nettyFuzzerTest)
     dependsOn(lz4FrameDecoderRegression)
     dependsOn(httpClientUpgradeHandlerRegression)
     dependsOn(brotliDecoderRegression)

--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -24,7 +24,10 @@ tasks.withType<JavaCompile> {
 }
 
 tasks.withType<Test>() {
-    jvmArgs("--enable-preview")
+    jvmArgs(
+        "--enable-preview",
+        "-Dio.netty.customResourceLeakDetector=io.netty.util.LeakPresenceDetector"
+    )
 }
 
 tasks.named<Test>("test") {
@@ -189,6 +192,9 @@ dependencies {
     implementation("org.lz4:lz4-java:1.8.0")
     runtimeOnly("org.bouncycastle:bcpkix-jdk18on:1.84")
     implementation("io.netty:netty-codec-xml")
+    implementation("io.netty:netty-codec-haproxy") {
+        version { strictly("4.2.14.Final") }
+    }
 
     annotationProcessor(mn.micronaut.inject.java)
     annotationProcessor(projects.micronautFuzzingAnnotationProcessor)
@@ -253,9 +259,11 @@ tasks.named<JazzerTask>("jazzer") {
     targets.set(listOf(
         //"io.micronaut.fuzzing.toml.TomlTarget",
         //"io.micronaut.fuzzing.http.HttpTarget",
-        "io.micronaut.fuzzing.http.EmbeddedHttpTarget",
+       // "io.micronaut.fuzzing.http.EmbeddedHttpTarget",
         //"io.micronaut.fuzzing.http.MediaTypeTarget",
-        //"io.netty.handler.HttpRequestDecoderFuzzer"
+        //"io.netty.handler.HttpRequestDecoderFuzzer",
+        //"io.netty.handler.codec.haproxy.HAProxyMessageDecoderFuzzer",
+        //"io.netty.handler.ssl.SniHandlerFuzzer",
         //"io.micronaut.fuzzing.http.UriMatchTemplateTarget",
         //"io.micronaut.fuzzing.http.TypeConversionTarget",
         //"io.micronaut.fuzzing.http.ContentNegotiationTarget",

--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -48,6 +48,13 @@ val nettyFuzzerTest by tasks.registering(Test::class) {
     shouldRunAfter(tasks.named("test"))
     forkEvery = 1
     jvmArgs("-Dio.netty.customResourceLeakDetector=io.netty.util.LeakPresenceDetector")
+
+    extensions.configure<JacocoTaskExtension> {
+        isEnabled = false
+    }
+    doFirst {
+        jvmArgumentProviders.removeAll { it.javaClass.name.contains("Jacoco") }
+    }
 }
 
 val lz4FrameDecoderRegression by tasks.registering(JazzerRegressionTask::class) {

--- a/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/CookieParsingTarget.java
+++ b/fuzzing-tests/src/main/java/io/micronaut/fuzzing/http/CookieParsingTarget.java
@@ -26,6 +26,9 @@ import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
 
 import java.util.Collection;
 
+/**
+ * Fuzzes Netty server cookie decoding and encoding.
+ */
 @FuzzTarget
 @Dict({
     "session=abc123",
@@ -57,11 +60,12 @@ import java.util.Collection;
 public class CookieParsingTarget {
 
     public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-        int scenario = data.consumeInt(0, 3);
+        int scenario = data.consumeInt(0, 2);
         switch (scenario) {
             case 0 -> decodeStrict(data);
             case 1 -> decodeLax(data);
             case 2 -> encodeDecodeRoundTrip(data);
+            default -> throw new IllegalStateException("Unexpected scenario");
         }
     }
 
@@ -74,6 +78,7 @@ public class CookieParsingTarget {
                 c.value();
             }
         } catch (IllegalArgumentException ignored) {
+            // Invalid cookie syntax is expected fuzz input for the strict decoder.
         }
     }
 
@@ -86,6 +91,7 @@ public class CookieParsingTarget {
                 c.value();
             }
         } catch (IllegalArgumentException ignored) {
+            // Invalid cookie syntax is expected fuzz input for the lax decoder.
         }
     }
 

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorFuzzer.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.netty.handler.codec.http.websocketx;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import io.micronaut.fuzzing.Dict;
+import io.micronaut.fuzzing.FuzzTarget;
+import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import io.micronaut.fuzzing.util.ByteSplitter;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.MessageAggregationException;
+import io.netty.handler.codec.PrematureChannelClosureException;
+import io.netty.handler.codec.TooLongFrameException;
+import io.netty.util.LeakPresenceDetector;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.FastThreadLocalThread;
+
+/**
+ * Fuzzing support type.
+ */
+@FuzzTarget
+@Dict({
+    "SEP", "text", "binary", "continuation", "ping", "pong", "close"
+})
+public class WebSocketFrameAggregatorFuzzer {
+    private static final String SEPARATOR = "SEP";
+    private static final ByteSplitter SPLITTER = ByteSplitter.create(SEPARATOR);
+    private static final int MAX_CONTENT_LENGTH = 1024;
+    private static final int MAX_FRAME_COUNT = 64;
+    private static final int MAX_DATA_FRAME_BYTES = 512;
+    private static final int MAX_CONTROL_FRAME_BYTES = 125;
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) {
+        FastThreadLocalThread.runWithFastThreadLocal(() -> test0(fuzzedDataProvider));
+    }
+
+    private static void test0(FuzzedDataProvider fuzzedDataProvider) {
+        EmbeddedChannel channel = new EmbeddedChannel(
+            new WebSocketFrameAggregator(fuzzedDataProvider.consumeInt(0, MAX_CONTENT_LENGTH)),
+            new ReleaseAndIgnoreExpectedExceptionsHandler()
+        );
+        byte[] allBytes = fuzzedDataProvider.consumeRemainingAsBytes();
+        ByteSplitter.ChunkIterator itr = SPLITTER.splitIterator(allBytes);
+        try {
+            for (int i = 0; i < MAX_FRAME_COUNT && channel.isOpen() && itr.hasNext(); i++) {
+                itr.proceed();
+                channel.writeInbound(nextFrame(channel, allBytes, itr.start(), itr.length()));
+            }
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+        LeakPresenceDetector.check();
+    }
+
+    private static WebSocketFrame nextFrame(EmbeddedChannel channel, byte[] frameBytes, int offset, int length) {
+        int descriptor = length == 0 ? 0 : frameBytes[offset] & 0xff;
+        boolean finalFragment = (descriptor & 1) != 0;
+        int rsv = descriptor >> 1 & 7;
+        int payloadOffset = offset + Math.min(1, length);
+        int payloadLength = offset + length - payloadOffset;
+
+        return switch ((descriptor >> 4) % 6) {
+            case 0 -> new TextWebSocketFrame(
+                finalFragment, rsv, nextPayload(channel, frameBytes, payloadOffset, payloadLength, MAX_DATA_FRAME_BYTES)
+            );
+            case 1 -> new BinaryWebSocketFrame(
+                finalFragment, rsv, nextPayload(channel, frameBytes, payloadOffset, payloadLength, MAX_DATA_FRAME_BYTES)
+            );
+            case 2 -> new ContinuationWebSocketFrame(
+                finalFragment, rsv, nextPayload(channel, frameBytes, payloadOffset, payloadLength, MAX_DATA_FRAME_BYTES)
+            );
+            case 3 -> new PingWebSocketFrame(
+                finalFragment, rsv, nextPayload(channel, frameBytes, payloadOffset, payloadLength, MAX_CONTROL_FRAME_BYTES)
+            );
+            case 4 -> new PongWebSocketFrame(
+                finalFragment, rsv, nextPayload(channel, frameBytes, payloadOffset, payloadLength, MAX_CONTROL_FRAME_BYTES)
+            );
+            case 5 -> new CloseWebSocketFrame(
+                finalFragment, rsv, nextPayload(channel, frameBytes, payloadOffset, payloadLength, MAX_CONTROL_FRAME_BYTES)
+            );
+            default -> throw new IllegalStateException("Unexpected frame type");
+        };
+    }
+
+    private static ByteBuf nextPayload(EmbeddedChannel channel, byte[] frameBytes, int offset, int payloadLength, int maxLength) {
+        int length = Math.min(maxLength, payloadLength);
+        ByteBuf payload = channel.alloc().buffer(length);
+        payload.writeBytes(frameBytes, offset, length);
+        return payload;
+    }
+
+    public static void main(String[] args) {
+        LocalJazzerRunner.create(WebSocketFrameAggregatorFuzzer.class).fuzz();
+    }
+
+    private static final class ReleaseAndIgnoreExpectedExceptionsHandler extends ChannelInboundHandlerAdapter {
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+            ReferenceCountUtil.release(msg);
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            if (cause instanceof MessageAggregationException
+                || cause instanceof PrematureChannelClosureException
+                || cause instanceof TooLongFrameException) {
+                ctx.close();
+                return;
+            }
+            super.exceptionCaught(ctx, cause);
+        }
+    }
+}

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorFuzzer.java
@@ -19,111 +19,56 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import io.micronaut.fuzzing.Dict;
 import io.micronaut.fuzzing.FuzzTarget;
 import io.micronaut.fuzzing.runner.LocalJazzerRunner;
-import io.micronaut.fuzzing.util.ByteSplitter;
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.HandlerFuzzerBase;
+import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.handler.codec.MessageAggregationException;
 import io.netty.handler.codec.PrematureChannelClosureException;
 import io.netty.handler.codec.TooLongFrameException;
-import io.netty.util.LeakPresenceDetector;
-import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.FastThreadLocalThread;
 
 /**
  * Fuzzing support type.
  */
 @FuzzTarget
 @Dict({
-    "SEP", "text", "binary", "continuation", "ping", "pong", "close"
+    "text", "binary", "continuation", "ping", "pong", "close",
+    "\u0000\u0000", "\u0001\u0000", "\u0002\u0000", "\b\u0000", "\t\u0000", "\n\u0000",
+    "\u0001\u007e", "\u0002\u007e"
 })
-public class WebSocketFrameAggregatorFuzzer {
-    private static final String SEPARATOR = "SEP";
-    private static final ByteSplitter SPLITTER = ByteSplitter.create(SEPARATOR);
+public final class WebSocketFrameAggregatorFuzzer extends HandlerFuzzerBase {
     private static final int MAX_CONTENT_LENGTH = 1024;
-    private static final int MAX_FRAME_COUNT = 64;
-    private static final int MAX_DATA_FRAME_BYTES = 512;
-    private static final int MAX_CONTROL_FRAME_BYTES = 125;
+    private static final int MAX_FRAME_PAYLOAD_LENGTH = 1024;
 
-    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) {
-        FastThreadLocalThread.runWithFastThreadLocal(() -> test0(fuzzedDataProvider));
+    private final int maxContentLength;
+
+    private WebSocketFrameAggregatorFuzzer(FuzzedDataProvider fuzzedDataProvider) {
+        maxContentLength = fuzzedDataProvider.consumeInt(0, MAX_CONTENT_LENGTH);
     }
 
-    private static void test0(FuzzedDataProvider fuzzedDataProvider) {
-        EmbeddedChannel channel = new EmbeddedChannel(
-            new WebSocketFrameAggregator(fuzzedDataProvider.consumeInt(0, MAX_CONTENT_LENGTH)),
-            new ReleaseAndIgnoreExpectedExceptionsHandler()
+    @Override
+    protected EmbeddedChannel setUp() {
+        return new EmbeddedChannel(
+            new WebSocket08FrameDecoder(false, true, MAX_FRAME_PAYLOAD_LENGTH, true),
+            new WebSocketFrameAggregator(maxContentLength)
         );
-        byte[] allBytes = fuzzedDataProvider.consumeRemainingAsBytes();
-        ByteSplitter.ChunkIterator itr = SPLITTER.splitIterator(allBytes);
-        try {
-            for (int i = 0; i < MAX_FRAME_COUNT && channel.isOpen() && itr.hasNext(); i++) {
-                itr.proceed();
-                channel.writeInbound(nextFrame(channel, allBytes, itr.start(), itr.length()));
-            }
-        } finally {
-            channel.finishAndReleaseAll();
+    }
+
+    @Override
+    protected void onException(Exception e) {
+        if (e instanceof CorruptedFrameException
+            || e instanceof MessageAggregationException
+            || e instanceof PrematureChannelClosureException
+            || e instanceof TooLongFrameException) {
+            return;
         }
-        LeakPresenceDetector.check();
+        super.onException(e);
     }
 
-    private static WebSocketFrame nextFrame(EmbeddedChannel channel, byte[] frameBytes, int offset, int length) {
-        int descriptor = length == 0 ? 0 : frameBytes[offset] & 0xff;
-        boolean finalFragment = (descriptor & 1) != 0;
-        int rsv = descriptor >> 1 & 7;
-        int payloadOffset = offset + Math.min(1, length);
-        int payloadLength = offset + length - payloadOffset;
-
-        return switch ((descriptor >> 4) % 6) {
-            case 0 -> new TextWebSocketFrame(
-                finalFragment, rsv, nextPayload(channel, frameBytes, payloadOffset, payloadLength, MAX_DATA_FRAME_BYTES)
-            );
-            case 1 -> new BinaryWebSocketFrame(
-                finalFragment, rsv, nextPayload(channel, frameBytes, payloadOffset, payloadLength, MAX_DATA_FRAME_BYTES)
-            );
-            case 2 -> new ContinuationWebSocketFrame(
-                finalFragment, rsv, nextPayload(channel, frameBytes, payloadOffset, payloadLength, MAX_DATA_FRAME_BYTES)
-            );
-            case 3 -> new PingWebSocketFrame(
-                finalFragment, rsv, nextPayload(channel, frameBytes, payloadOffset, payloadLength, MAX_CONTROL_FRAME_BYTES)
-            );
-            case 4 -> new PongWebSocketFrame(
-                finalFragment, rsv, nextPayload(channel, frameBytes, payloadOffset, payloadLength, MAX_CONTROL_FRAME_BYTES)
-            );
-            case 5 -> new CloseWebSocketFrame(
-                finalFragment, rsv, nextPayload(channel, frameBytes, payloadOffset, payloadLength, MAX_CONTROL_FRAME_BYTES)
-            );
-            default -> throw new IllegalStateException("Unexpected frame type");
-        };
-    }
-
-    private static ByteBuf nextPayload(EmbeddedChannel channel, byte[] frameBytes, int offset, int payloadLength, int maxLength) {
-        int length = Math.min(maxLength, payloadLength);
-        ByteBuf payload = channel.alloc().buffer(length);
-        payload.writeBytes(frameBytes, offset, length);
-        return payload;
+    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) throws Exception {
+        new WebSocketFrameAggregatorFuzzer(fuzzedDataProvider).test(fuzzedDataProvider);
     }
 
     public static void main(String[] args) {
         LocalJazzerRunner.create(WebSocketFrameAggregatorFuzzer.class).fuzz();
-    }
-
-    private static final class ReleaseAndIgnoreExpectedExceptionsHandler extends ChannelInboundHandlerAdapter {
-        @Override
-        public void channelRead(ChannelHandlerContext ctx, Object msg) {
-            ReferenceCountUtil.release(msg);
-        }
-
-        @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            if (cause instanceof MessageAggregationException
-                || cause instanceof PrematureChannelClosureException
-                || cause instanceof TooLongFrameException) {
-                ctx.close();
-                return;
-            }
-            super.exceptionCaught(ctx, cause);
-        }
     }
 }

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerFuzzer.java
@@ -20,6 +20,7 @@ import io.micronaut.fuzzing.Dict;
 import io.micronaut.fuzzing.FuzzTarget;
 import io.micronaut.fuzzing.HttpDict;
 import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.HandlerFuzzerBase;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.PrematureChannelClosureException;
@@ -27,7 +28,6 @@ import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.util.AsciiString;
 
-import javax.net.ssl.SSLException;
 import java.nio.channels.ClosedChannelException;
 
 /**
@@ -43,7 +43,9 @@ import java.nio.channels.ClosedChannelException;
     "h2c"
 })
 public class CleartextHttp2ServerUpgradeHandlerFuzzer extends HandlerFuzzerBase {
-    public CleartextHttp2ServerUpgradeHandlerFuzzer(FuzzedDataProvider fuzzedDataProvider) {
+    @Override
+    protected EmbeddedChannel setUp() {
+        EmbeddedChannel channel = new EmbeddedChannel();
         HttpServerCodec serverCodec = new HttpServerCodec();
         HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(serverCodec, protocol -> {
             if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
@@ -58,6 +60,7 @@ public class CleartextHttp2ServerUpgradeHandlerFuzzer extends HandlerFuzzerBase 
                 upgradeHandler,
                 Http2FrameCodecBuilder.forServer().build()
             ));
+        return channel;
     }
 
     @Override
@@ -66,15 +69,14 @@ public class CleartextHttp2ServerUpgradeHandlerFuzzer extends HandlerFuzzerBase 
             || e instanceof Http2FrameStreamException
             || e instanceof PrematureChannelClosureException
             || e instanceof ClosedChannelException
-            || e instanceof DecoderException && e.getCause() instanceof Http2Exception) {
+            || (e instanceof DecoderException && e.getCause() instanceof Http2Exception)) {
             return;
         }
         super.onException(e);
     }
 
-    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) throws SSLException {
-        var fuzzer = new CleartextHttp2ServerUpgradeHandlerFuzzer(fuzzedDataProvider);
-        fuzzer.test(fuzzedDataProvider);
+    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) throws Exception {
+        new CleartextHttp2ServerUpgradeHandlerFuzzer().test(fuzzedDataProvider);
     }
 
     public static void main(String[] args) {

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerFuzzer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import io.micronaut.fuzzing.Dict;
+import io.micronaut.fuzzing.FuzzTarget;
+import io.micronaut.fuzzing.HttpDict;
+import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import io.netty.handler.HandlerFuzzerBase;
+import io.netty.handler.codec.DecoderException;
+import io.netty.handler.codec.PrematureChannelClosureException;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpServerUpgradeHandler;
+import io.netty.util.AsciiString;
+
+import javax.net.ssl.SSLException;
+import java.nio.channels.ClosedChannelException;
+
+/**
+ * Fuzzing support type.
+ */
+@FuzzTarget
+@HttpDict
+@Dict({
+    "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+    "Upgrade: h2c\r\n",
+    "HTTP2-Settings",
+    "Connection: Upgrade, HTTP2-Settings\r\n",
+    "h2c"
+})
+public class CleartextHttp2ServerUpgradeHandlerFuzzer extends HandlerFuzzerBase {
+    public CleartextHttp2ServerUpgradeHandlerFuzzer(FuzzedDataProvider fuzzedDataProvider) {
+        HttpServerCodec serverCodec = new HttpServerCodec();
+        HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(serverCodec, protocol -> {
+            if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
+                return new Http2ServerUpgradeCodec(Http2FrameCodecBuilder.forServer().build());
+            }
+            return null;
+        }, 1024);
+
+        channel.pipeline()
+            .addLast(new CleartextHttp2ServerUpgradeHandler(
+                serverCodec,
+                upgradeHandler,
+                Http2FrameCodecBuilder.forServer().build()
+            ));
+    }
+
+    @Override
+    protected void onException(Exception e) {
+        if (e instanceof Http2Exception
+            || e instanceof Http2FrameStreamException
+            || e instanceof PrematureChannelClosureException
+            || e instanceof ClosedChannelException
+            || e instanceof DecoderException && e.getCause() instanceof Http2Exception) {
+            return;
+        }
+        super.onException(e);
+    }
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) throws SSLException {
+        var fuzzer = new CleartextHttp2ServerUpgradeHandlerFuzzer(fuzzedDataProvider);
+        fuzzer.test(fuzzedDataProvider);
+    }
+
+    public static void main(String[] args) {
+        LocalJazzerRunner.create(CleartextHttp2ServerUpgradeHandlerFuzzer.class).fuzz();
+    }
+}

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandlerFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandlerFuzzer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import io.micronaut.fuzzing.Dict;
+import io.micronaut.fuzzing.FuzzTarget;
+import io.micronaut.fuzzing.HttpDict;
+import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import io.netty.handler.HandlerFuzzerBase;
+import io.netty.handler.codec.DecoderException;
+import io.netty.handler.codec.PrematureChannelClosureException;
+
+import javax.net.ssl.SSLException;
+import java.nio.channels.ClosedChannelException;
+
+/**
+ * Fuzzing support type.
+ */
+@FuzzTarget
+@HttpDict
+@Dict({
+    "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+    "\u0000\u0000\u0000\u0004\u0000\u0000\u0000\u0000\u0000",
+    "\u0000\u0000\b\u0006\u0000\u0000\u0000\u0000\u0000",
+    "\u0000\u0000\u0000\u0004\u0001\u0000\u0000\u0000\u0000"
+})
+public class Http2ConnectionHandlerFuzzer extends HandlerFuzzerBase {
+    public Http2ConnectionHandlerFuzzer(FuzzedDataProvider fuzzedDataProvider) {
+        channel.pipeline()
+            .addLast(new Http2ConnectionHandlerBuilder()
+                .server(true)
+                .frameListener(new Http2FrameAdapter())
+                .build());
+    }
+
+    @Override
+    protected void onException(Exception e) {
+        if (e instanceof Http2Exception
+            || e instanceof Http2FrameStreamException
+            || e instanceof PrematureChannelClosureException
+            || e instanceof ClosedChannelException
+            || e instanceof DecoderException && e.getCause() instanceof Http2Exception) {
+            return;
+        }
+        super.onException(e);
+    }
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) throws SSLException {
+        var fuzzer = new Http2ConnectionHandlerFuzzer(fuzzedDataProvider);
+        fuzzer.test(fuzzedDataProvider);
+    }
+
+    public static void main(String[] args) {
+        LocalJazzerRunner.create(Http2ConnectionHandlerFuzzer.class).fuzz();
+    }
+}

--- a/fuzzing-tests/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandlerFuzzer.java
+++ b/fuzzing-tests/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandlerFuzzer.java
@@ -20,11 +20,11 @@ import io.micronaut.fuzzing.Dict;
 import io.micronaut.fuzzing.FuzzTarget;
 import io.micronaut.fuzzing.HttpDict;
 import io.micronaut.fuzzing.runner.LocalJazzerRunner;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.HandlerFuzzerBase;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.PrematureChannelClosureException;
 
-import javax.net.ssl.SSLException;
 import java.nio.channels.ClosedChannelException;
 
 /**
@@ -39,12 +39,15 @@ import java.nio.channels.ClosedChannelException;
     "\u0000\u0000\u0000\u0004\u0001\u0000\u0000\u0000\u0000"
 })
 public class Http2ConnectionHandlerFuzzer extends HandlerFuzzerBase {
-    public Http2ConnectionHandlerFuzzer(FuzzedDataProvider fuzzedDataProvider) {
+    @Override
+    protected EmbeddedChannel setUp() {
+        EmbeddedChannel channel = new EmbeddedChannel();
         channel.pipeline()
             .addLast(new Http2ConnectionHandlerBuilder()
                 .server(true)
                 .frameListener(new Http2FrameAdapter())
                 .build());
+        return channel;
     }
 
     @Override
@@ -53,15 +56,14 @@ public class Http2ConnectionHandlerFuzzer extends HandlerFuzzerBase {
             || e instanceof Http2FrameStreamException
             || e instanceof PrematureChannelClosureException
             || e instanceof ClosedChannelException
-            || e instanceof DecoderException && e.getCause() instanceof Http2Exception) {
+            || (e instanceof DecoderException && e.getCause() instanceof Http2Exception)) {
             return;
         }
         super.onException(e);
     }
 
-    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) throws SSLException {
-        var fuzzer = new Http2ConnectionHandlerFuzzer(fuzzedDataProvider);
-        fuzzer.test(fuzzedDataProvider);
+    public static void fuzzerTestOneInput(FuzzedDataProvider fuzzedDataProvider) throws Exception {
+        new Http2ConnectionHandlerFuzzer().test(fuzzedDataProvider);
     }
 
     public static void main(String[] args) {

--- a/fuzzing-tests/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorFuzzerTest.java
+++ b/fuzzing-tests/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorFuzzerTest.java
@@ -1,0 +1,76 @@
+package io.netty.handler.codec.http.websocketx;
+
+import com.code_intelligence.jazzer.api.CannedFuzzedDataProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+class WebSocketFrameAggregatorFuzzerTest {
+    private static final int TEXT = 0;
+    private static final int PING_FINAL = 3 << 4 | 1;
+    private static final int CONTINUATION = 2 << 4;
+    private static final int FINAL_CONTINUATION = 2 << 4 | 1;
+
+    @BeforeAll
+    static void configureLeakDetector() {
+        System.setProperty("io.netty.customResourceLeakDetector", "io.netty.util.LeakPresenceDetector");
+    }
+
+    @Test
+    void fuzzesFragmentedFramesWithInterleavedControlFrame() {
+        WebSocketFrameAggregatorFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.of(
+            16,
+            frames(
+                frame(TEXT, "hello"),
+                frame(PING_FINAL, new byte[] { 1 }),
+                frame(CONTINUATION, " world"),
+                frame(FINAL_CONTINUATION, "!")
+            )
+        )));
+    }
+
+    @Test
+    void handlesOversizedAggregatesAsExpectedNettyValidation() {
+        WebSocketFrameAggregatorFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.of(
+            4,
+            frames(
+                frame(TEXT, "test"),
+                frame(FINAL_CONTINUATION, "!")
+            )
+        )));
+    }
+
+    private static byte[] frames(byte[]... frames) {
+        byte[] separator = "SEP".getBytes(UTF_8);
+        int length = Math.max(0, frames.length - 1) * separator.length;
+        for (byte[] frame : frames) {
+            length += frame.length;
+        }
+
+        byte[] result = new byte[length];
+        int offset = 0;
+        for (int i = 0; i < frames.length; i++) {
+            System.arraycopy(frames[i], 0, result, offset, frames[i].length);
+            offset += frames[i].length;
+            if (i != frames.length - 1) {
+                System.arraycopy(separator, 0, result, offset, separator.length);
+                offset += separator.length;
+            }
+        }
+        return result;
+    }
+
+    private static byte[] frame(int descriptor, String payload) {
+        return frame(descriptor, payload.getBytes(UTF_8));
+    }
+
+    private static byte[] frame(int descriptor, byte[] payload) {
+        byte[] frame = new byte[payload.length + 1];
+        frame[0] = (byte) descriptor;
+        System.arraycopy(payload, 0, frame, 1, payload.length);
+        return frame;
+    }
+}

--- a/fuzzing-tests/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorFuzzerTest.java
+++ b/fuzzing-tests/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorFuzzerTest.java
@@ -1,7 +1,6 @@
 package io.netty.handler.codec.http.websocketx;
 
 import com.code_intelligence.jazzer.api.CannedFuzzedDataProvider;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -9,18 +8,19 @@ import java.util.List;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 class WebSocketFrameAggregatorFuzzerTest {
-    private static final int TEXT = 0;
-    private static final int PING_FINAL = 3 << 4 | 1;
-    private static final int CONTINUATION = 2 << 4;
-    private static final int FINAL_CONTINUATION = 2 << 4 | 1;
-
-    @BeforeAll
-    static void configureLeakDetector() {
-        System.setProperty("io.netty.customResourceLeakDetector", "io.netty.util.LeakPresenceDetector");
-    }
+    private static final int TEXT = 1;
+    private static final int FINAL_TEXT = 0x80 | TEXT;
+    private static final int BINARY = 2;
+    private static final int FINAL_BINARY = 0x80 | BINARY;
+    private static final int PING_FINAL = 0x80 | 9;
+    private static final int PONG_FINAL = 0x80 | 10;
+    private static final int CLOSE_FINAL = 0x80 | 8;
+    private static final int CONTINUATION = 0;
+    private static final int FINAL_CONTINUATION = 0x80;
+    private static final int RSV1_FINAL_TEXT = 0xc0 | TEXT;
 
     @Test
-    void fuzzesFragmentedFramesWithInterleavedControlFrame() {
+    void fuzzesFragmentedFramesWithInterleavedControlFrame() throws Exception {
         WebSocketFrameAggregatorFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.of(
             16,
             frames(
@@ -33,12 +33,65 @@ class WebSocketFrameAggregatorFuzzerTest {
     }
 
     @Test
-    void handlesOversizedAggregatesAsExpectedNettyValidation() {
+    void handlesOversizedAggregatesAsExpectedNettyValidation() throws Exception {
         WebSocketFrameAggregatorFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.of(
             4,
             frames(
                 frame(TEXT, "test"),
                 frame(FINAL_CONTINUATION, "!")
+            )
+        )));
+    }
+
+    @Test
+    void fuzzesFragmentedBinaryFrames() throws Exception {
+        WebSocketFrameAggregatorFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.of(
+            16,
+            frames(
+                frame(BINARY, new byte[] { 1 }),
+                frame(CONTINUATION, new byte[] { 2 }),
+                frame(FINAL_CONTINUATION, new byte[] { 3 })
+            )
+        )));
+    }
+
+    @Test
+    void fuzzesSingleFinalTextFrame() throws Exception {
+        WebSocketFrameAggregatorFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.of(
+            16,
+            frame(FINAL_TEXT, "hello")
+        )));
+    }
+
+    @Test
+    void decoderReplacementCanReachOldFrameCategories() throws Exception {
+        WebSocketFrameAggregatorFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.of(
+            16,
+            frames(
+                frame(FINAL_TEXT, "text"),
+                frame(FINAL_BINARY, new byte[] { 1, 2, 3 }),
+                frame(PING_FINAL, new byte[] { 4 }),
+                frame(PONG_FINAL, new byte[] { 5 }),
+                closeFrame()
+            )
+        )));
+    }
+
+    @Test
+    void decoderReplacementCanReachRsvPathsAllowedByExtensions() throws Exception {
+        WebSocketFrameAggregatorFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.of(
+            16,
+            frame(RSV1_FINAL_TEXT, "reserved")
+        )));
+    }
+
+    @Test
+    void decoderReplacementCanAggregateRsvFragmentedFrames() throws Exception {
+        WebSocketFrameAggregatorFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.of(
+            16,
+            frames(
+                frame(0x40 | TEXT, "reserved"),
+                frame(FINAL_CONTINUATION, " continuation")
             )
         )));
     }
@@ -68,9 +121,14 @@ class WebSocketFrameAggregatorFuzzerTest {
     }
 
     private static byte[] frame(int descriptor, byte[] payload) {
-        byte[] frame = new byte[payload.length + 1];
+        byte[] frame = new byte[payload.length + 2];
         frame[0] = (byte) descriptor;
-        System.arraycopy(payload, 0, frame, 1, payload.length);
+        frame[1] = (byte) payload.length;
+        System.arraycopy(payload, 0, frame, 2, payload.length);
         return frame;
+    }
+
+    private static byte[] closeFrame() {
+        return frame(CLOSE_FINAL, new byte[] { 3, (byte) 232 });
     }
 }

--- a/fuzzing-tests/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerFuzzerTest.java
+++ b/fuzzing-tests/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerFuzzerTest.java
@@ -1,18 +1,12 @@
 package io.netty.handler.codec.http2;
 
 import com.code_intelligence.jazzer.api.CannedFuzzedDataProvider;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 class CleartextHttp2ServerUpgradeHandlerFuzzerTest {
-    @BeforeAll
-    static void configureLeakDetector() {
-        System.setProperty("io.netty.customResourceLeakDetector", "io.netty.util.LeakPresenceDetector");
-    }
-
     @Test
     void fuzzesPriorKnowledgePrefaceAcrossChunks() throws Exception {
         CleartextHttp2ServerUpgradeHandlerFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.<Object>of(

--- a/fuzzing-tests/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerFuzzerTest.java
+++ b/fuzzing-tests/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerFuzzerTest.java
@@ -1,0 +1,38 @@
+package io.netty.handler.codec.http2;
+
+import com.code_intelligence.jazzer.api.CannedFuzzedDataProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+class CleartextHttp2ServerUpgradeHandlerFuzzerTest {
+    @BeforeAll
+    static void configureLeakDetector() {
+        System.setProperty("io.netty.customResourceLeakDetector", "io.netty.util.LeakPresenceDetector");
+    }
+
+    @Test
+    void fuzzesPriorKnowledgePrefaceAcrossChunks() throws Exception {
+        CleartextHttp2ServerUpgradeHandlerFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.<Object>of(
+            bytes("PRI * HTTP/2.0\r\n\r\nSSEPM\r\n\r\n")
+        )));
+    }
+
+    @Test
+    void fuzzesHttp1UpgradeRequestAcrossChunks() throws Exception {
+        CleartextHttp2ServerUpgradeHandlerFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.<Object>of(
+            bytes("GET / HTTP/1.1\r\n"
+                + "Host: localhost\r\n"
+                + "Connection: Upgrade, HTTP2-Settings\r\n"
+                + "Upgrade: h2c\r\n"
+                + "HTTP2-Settings: AAMAAABkAAQAAP__\r\n"
+                + "SEP\r\n")
+        )));
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.US_ASCII);
+    }
+}

--- a/fuzzing-tests/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerFuzzerTest.java
+++ b/fuzzing-tests/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerFuzzerTest.java
@@ -1,0 +1,47 @@
+package io.netty.handler.codec.http2;
+
+import com.code_intelligence.jazzer.api.CannedFuzzedDataProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+class Http2ConnectionHandlerFuzzerTest {
+    private static final byte[] EMPTY_SETTINGS_FRAME = {
+        0, 0, 0,
+        4,
+        0,
+        0, 0, 0, 0
+    };
+
+    @BeforeAll
+    static void configureLeakDetector() {
+        System.setProperty("io.netty.customResourceLeakDetector", "io.netty.util.LeakPresenceDetector");
+    }
+
+    @Test
+    void fuzzesConnectionPrefaceAndSettingsAcrossChunks() throws Exception {
+        Http2ConnectionHandlerFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.<Object>of(
+            concat(bytes("PRI * HTTP/2.0\r\n\r\nSSEPM\r\n\r\n"), EMPTY_SETTINGS_FRAME)
+        )));
+    }
+
+    @Test
+    void handlesInvalidHttp1PrefaceAsExpectedNettyValidation() throws Exception {
+        Http2ConnectionHandlerFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.<Object>of(
+            bytes("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        )));
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.US_ASCII);
+    }
+
+    private static byte[] concat(byte[] first, byte[] second) {
+        byte[] result = new byte[first.length + second.length];
+        System.arraycopy(first, 0, result, 0, first.length);
+        System.arraycopy(second, 0, result, first.length, second.length);
+        return result;
+    }
+}

--- a/fuzzing-tests/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerFuzzerTest.java
+++ b/fuzzing-tests/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerFuzzerTest.java
@@ -1,7 +1,6 @@
 package io.netty.handler.codec.http2;
 
 import com.code_intelligence.jazzer.api.CannedFuzzedDataProvider;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -14,11 +13,6 @@ class Http2ConnectionHandlerFuzzerTest {
         0,
         0, 0, 0, 0
     };
-
-    @BeforeAll
-    static void configureLeakDetector() {
-        System.setProperty("io.netty.customResourceLeakDetector", "io.netty.util.LeakPresenceDetector");
-    }
 
     @Test
     void fuzzesConnectionPrefaceAndSettingsAcrossChunks() throws Exception {

--- a/fuzzing-tests/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerFuzzerTest.java
+++ b/fuzzing-tests/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerFuzzerTest.java
@@ -17,7 +17,7 @@ class Http2ConnectionHandlerFuzzerTest {
     @Test
     void fuzzesConnectionPrefaceAndSettingsAcrossChunks() throws Exception {
         Http2ConnectionHandlerFuzzer.fuzzerTestOneInput(CannedFuzzedDataProvider.create(List.<Object>of(
-            concat(bytes("PRI * HTTP/2.0\r\n\r\nSSEPM\r\n\r\n"), EMPTY_SETTINGS_FRAME)
+            concat(bytes("PRI * HTTP/2.0\r\n\r\nSSEPM\r\n\r\nSEP"), EMPTY_SETTINGS_FRAME)
         )));
     }
 


### PR DESCRIPTION
Add fuzz targets and tests for WebSocketFrameAggregator,
CleartextHttp2ServerUpgradeHandler, and Http2ConnectionHandler.