### PR TITLE
Fix LZ4 decoder fuzz regression

### DIFF
--- a/fuzzing-tests/build.gradle.kts
+++ b/fuzzing-tests/build.gradle.kts
@@ -79,6 +79,13 @@ val lz4FrameDecoderRegression by tasks.registering(JazzerRegressionTask::class) 
         U0VTRVBTRVBTRVBTRVBQRVBFU1NTRVBTU0VQU0VQU0VQUHJhZ21TRVBTRVBTRVBTRVBTRVBTRVBT
         RVBTRSpFUFNFUFNTRVBTRVBTRVA=
     """.trimIndent())
+    base64RegressionInputs.put("oss-fuzz-5957100319866880", """
+        TFo0QmxvY2suhAAAAABALAAAAGRWVlZUcn5uc2Zlci1FbmNvZGluZ1ZWVlZWVtZWXVZWVlZWVlZ+
+        bnNmZXItRW5jb2RpbmdWVlZWVlZWVl1WVlZWVlZWVoxWVkFjTDRaRkFjY2Vzcy1DcnRvb25sLUFs
+        U1BTRUVQU0VQU0WRgYGBgYGBgUxaNEJsb2NrLoQAAAAAQAAAAGRWVlZUcmFuc2Zlci1FbmNvZGlu
+        Z1ZWVlZWVlZWXVZWVlZWVlZWjFZWQWNMNFpGQWNjQ3Nyc2YtdG9QU0VQoIDzoK2p8gzzoIGAhL7z
+        oIGeKy3zoIGrdjDhhZ8xMzA0nQrzoICiMhE=
+    """.trimIndent())
 }
 
 val httpClientUpgradeHandlerRegression by tasks.registering(JazzerRegressionTask::class) {
@@ -213,7 +220,7 @@ dependencies {
     runtimeOnly("com.github.luben:zstd-jni:1.5.7-11")
     runtimeOnly("com.jcraft:jzlib:1.1.3")
     runtimeOnly("com.ning:compress-lzf:1.2.0")
-    implementation("org.lz4:lz4-java:1.8.0")
+    implementation("at.yawk.lz4:lz4-java:1.11.1")
     runtimeOnly("org.bouncycastle:bcpkix-jdk18on:1.84")
     implementation("io.netty:netty-codec-xml")
 


### PR DESCRIPTION
## Summary
- switch the LZ4 dependency from archived org.lz4:lz4-java:1.8.0 to maintained at.yawk.lz4:lz4-java:1.11.1
- add OSS-Fuzz testcase 5957100319866880 to the LZ4 frame decoder regression task

## Details
The old org.lz4 artifact can route malformed input through the native LZ4 fast decompressor. The maintained at.yawk.lz4 fork keeps the same net.jpountz package API while avoiding the unsafe native fast decompressor path by default.

## Verification
- ./gradlew :micronaut-fuzzing-tests:dependencyInsight --dependency lz4-java --configuration runtimeClasspath --no-daemon
- ./gradlew :micronaut-fuzzing-tests:lz4FrameDecoderRegression --no-daemon --stacktrace